### PR TITLE
chore(cloud-bootstrap): harden bootstrap from flux-review findings (P0/P1 + damage isolation)

### DIFF
--- a/.beads/PRIME.md
+++ b/.beads/PRIME.md
@@ -4,8 +4,9 @@
 > beads are read-only.** Search with `bash scripts/bd-grep.sh <kw>` and read
 > with `bash scripts/bd-show.sh <id>` — both work against the committed
 > `.beads/issues.jsonl` without needing the `bd` CLI. Note bead candidates in
-> the PR description and let the workstation file them. Skip the rest of this
-> file unless you've manually run `scripts/install-bd-cloud.sh`.
+> the PR description and let the workstation file them. Skip the **bd CLI
+> steps below** unless you've manually run `scripts/install-bd-cloud.sh` —
+> the `git`/PR workflow still applies.
 
 ```
 git status → git add <files> → git commit

--- a/.beads/heal-dolt.sh
+++ b/.beads/heal-dolt.sh
@@ -3,7 +3,6 @@
 # Called by SessionStart hook. Safe to run anytime.
 # Guard against infinite recursion: bd auto_heal calls this, and this calls bd
 [[ -n "${BD_HEALING:-}" ]] && exit 0
-export BD_HEALING=1
 
 set -euo pipefail
 
@@ -11,16 +10,39 @@ BEADS_DIR="${1:-.beads}"
 DOLT_DIR="$BEADS_DIR/dolt"
 DB_DIR="$DOLT_DIR/Sylveste"
 
-# If bd isn't on PATH, exit cleanly. This is the expected state in
-# cloud_default remote environments, where sessions read .beads/issues.jsonl
-# directly as a flat file rather than running the bd CLI. See CLAUDE.md
-# "Cloud Sessions" for the read-only-beads convention. For tasks that
-# genuinely need the bd CLI in a cloud container, run scripts/install-bd-cloud.sh
-# manually before starting work.
-if ! command -v bd >/dev/null 2>&1; then
-    echo "heal-dolt: bd not on PATH — skipping Dolt healing (cloud read-only mode)" >&2
-    exit 0
+# Cloud detection lives in the shared guard lib so every bd-invoking script
+# diagnoses the same way (see PR #19 follow-up — `command -v bd` is an
+# unreliable cloud proxy because a workstation with a broken PATH gets
+# misdiagnosed). Distinguish cloud (intent: read-only beads, skip silently)
+# from workstation-missing-bd (real bug, log actionably).
+GUARD_LIB="$(dirname "$BEADS_DIR")/scripts/lib-cloud-guard.sh"
+if [[ -r "$GUARD_LIB" ]]; then
+    # shellcheck source=../scripts/lib-cloud-guard.sh
+    source "$GUARD_LIB"
+    if cloud_session; then
+        cloud_log_skip "heal-dolt"
+        exit 0
+    fi
+    if ! command -v bd >/dev/null 2>&1; then
+        workstation_log_missing_bd "heal-dolt"
+        exit 0
+    fi
+else
+    # lib missing — fall back to legacy behavior (bd-presence only).
+    if ! command -v bd >/dev/null 2>&1; then
+        echo "heal-dolt: bd not on PATH (lib-cloud-guard.sh also missing) — skipping" >&2
+        exit 0
+    fi
 fi
+
+# Arm the recursion guard only now that we know bd will actually run.
+export BD_HEALING=1
+
+# Bounded budget for the whole heal operation (anytime stopping criterion).
+# Override with HEAL_DOLT_BUDGET_S for tuning. The default 5s captures ~95%
+# of healthy cold-starts; beyond that, fall through to the JSONL-fallback
+# path rather than block the user's first prompt indefinitely.
+HEAL_BUDGET_S="${HEAL_DOLT_BUDGET_S:-5}"
 
 heal_lock() {
     local info_file="$1"
@@ -28,7 +50,9 @@ heal_lock() {
 
     local pid
     pid=$(cut -d: -f1 "$info_file" 2>/dev/null) || return 0
-    [[ -z "$pid" ]] && return 0
+    # Defensive parse: bare PID files (no colon) make `cut` return the whole
+    # line. Require digits only before passing to kill.
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 0
 
     # Check if the PID is actually alive
     if ! kill -0 "$pid" 2>/dev/null; then
@@ -44,13 +68,32 @@ kill_orphans() {
     local tracked_pid=""
     [[ -f "$BEADS_DIR/dolt-server.pid" ]] && tracked_pid=$(cat "$BEADS_DIR/dolt-server.pid" 2>/dev/null)
 
-    local orphans
+    local orphans killed
     orphans=$(pgrep -f "dolt sql-server" 2>/dev/null || true)
+    killed=()
     for pid in $orphans; do
         if [[ "$pid" != "$tracked_pid" ]]; then
             echo "heal-dolt: killing orphaned dolt process $pid" >&2
             kill "$pid" 2>/dev/null || true
+            killed+=("$pid")
         fi
+    done
+
+    # Closed-loop wait: poll until killed PIDs are gone, up to 2s. Replaces a
+    # fixed `sleep 1` that was either pure latency (nominal load) or too short
+    # (slow disk + many orphans). Final SIGKILL on stragglers.
+    [[ ${#killed[@]} -eq 0 ]] && return 0
+    local i
+    for i in $(seq 1 20); do
+        local alive=0
+        for pid in "${killed[@]}"; do
+            kill -0 "$pid" 2>/dev/null && alive=1
+        done
+        [[ "$alive" -eq 0 ]] && return 0
+        sleep 0.1
+    done
+    for pid in "${killed[@]}"; do
+        kill -0 "$pid" 2>/dev/null && kill -KILL "$pid" 2>/dev/null || true
     done
 }
 
@@ -62,11 +105,33 @@ heal_lock "$DB_DIR/.dolt/sql-server.info" || healed=1
 # Phase 2: Kill orphaned dolt processes (only if we found stale locks)
 if [[ "$healed" -eq 1 ]]; then
     kill_orphans
-    sleep 1
 fi
 
-# Phase 3: Ensure Dolt is running
+# Phase 3: Ensure Dolt is running. Bound the start with a budget — if Dolt
+# can't come up within HEAL_BUDGET_S the downstream `bd stats || fallback`
+# in settings.json picks up the slack rather than blocking the user.
 if ! bd dolt status >/dev/null 2>&1; then
-    echo "heal-dolt: starting Dolt server" >&2
-    bd dolt start 2>&1 | tail -1 >&2
+    echo "heal-dolt: starting Dolt server (budget ${HEAL_BUDGET_S}s)" >&2
+    if ! out=$(timeout "${HEAL_BUDGET_S}" bd dolt start 2>&1); then
+        rc=$?
+        # timeout(1) returns 124 on timeout, 125+ on its own errors, otherwise
+        # propagates the child's code.
+        if [[ "$rc" -eq 124 ]]; then
+            echo "heal-dolt: bd dolt start exceeded ${HEAL_BUDGET_S}s budget; falling through" >&2
+        else
+            # Surface full error context (not just `tail -1`) for diagnosis.
+            echo "heal-dolt: bd dolt start failed (rc=$rc):" >&2
+            printf '%s\n' "$out" >&2
+        fi
+    else
+        # Readiness gap: `bd dolt status` (port open) trails Dolt accepting
+        # queries by ~500ms-2s. Poll `bd stats` until success or 2s, so the
+        # next caller doesn't race.
+        for _ in $(seq 1 20); do
+            bd stats >/dev/null 2>&1 && break
+            sleep 0.1
+        done
+        # echo back the start tail for observability
+        printf '%s\n' "$out" | tail -1 >&2
+    fi
 fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,7 @@
             "type": "command"
           }
         ],
-        "matcher": ""
+        "matcher": "manual"
       }
     ],
     "SessionStart": [

--- a/scripts/audit-roadmap-beads.sh
+++ b/scripts/audit-roadmap-beads.sh
@@ -19,6 +19,30 @@ done
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 ROADMAP="${ROADMAP:-$REPO_ROOT/docs/sylveste-roadmap.md}"
 
+# Cloud-guard: cloud sessions can't run bd; skip cleanly so we don't produce
+# misleading "missing from beads" results for every roadmap entry.
+GUARD_LIB="$REPO_ROOT/scripts/lib-cloud-guard.sh"
+if [[ -r "$GUARD_LIB" ]]; then
+    # shellcheck source=lib-cloud-guard.sh
+    source "$GUARD_LIB"
+    if cloud_session; then
+        if $JSON_MODE; then
+            echo '{"skipped":"cloud read-only mode","reason":"audit requires bd CLI"}'
+        else
+            cloud_log_skip "audit-roadmap-beads"
+        fi
+        exit 0
+    fi
+    if ! command -v bd >/dev/null 2>&1; then
+        if $JSON_MODE; then
+            echo '{"skipped":"bd not on PATH","reason":"workstation bd install required"}'
+        else
+            workstation_log_missing_bd "audit-roadmap-beads"
+        fi
+        exit 0
+    fi
+fi
+
 if [[ ! -f "$ROADMAP" ]]; then
     if $JSON_MODE; then
         echo '{"error":"roadmap not found","path":"'"$ROADMAP"'"}'

--- a/scripts/backfill-bead-labels.py
+++ b/scripts/backfill-bead-labels.py
@@ -36,6 +36,7 @@ import re
 import subprocess
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 
 # ---------------------------------------------------------------------------
 # Module detection
@@ -259,6 +260,23 @@ def detect_themes(title: str, description: str) -> set[str]:
 # ---------------------------------------------------------------------------
 
 def main() -> int:
+    # Cloud-guard: cloud sessions can't run bd; backfilling labels is a write
+    # operation that doesn't survive the ephemeral container. Skip cleanly.
+    import shutil
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    try:
+        from lib_cloud_guard import cloud_session, cloud_log_skip, workstation_log_missing_bd
+    except ImportError:
+        cloud_session = lambda: False  # type: ignore
+        cloud_log_skip = lambda op="op": None  # type: ignore
+        workstation_log_missing_bd = lambda op="op": None  # type: ignore
+    if cloud_session():
+        cloud_log_skip("backfill-bead-labels")
+        return 0
+    if shutil.which("bd") is None:
+        workstation_log_missing_bd("backfill-bead-labels")
+        return 0
+
     parser = argparse.ArgumentParser(description="Backfill theme and module labels onto beads.")
     parser.add_argument("--dry-run", action="store_true", help="Preview without applying")
     parser.add_argument("--limit", type=int, default=0, help="Limit to N beads (0=all)")

--- a/scripts/bd-create-checked.sh
+++ b/scripts/bd-create-checked.sh
@@ -19,6 +19,22 @@ set -u
 REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 LIB="${REPO_ROOT}/scripts/lib-bd-dup-check.py"
 
+# Cloud-guard: creating beads from cloud doesn't survive the ephemeral
+# container. Refuse loudly so the agent files the bead via PR description
+# instead of silently losing the write.
+GUARD_LIB="${REPO_ROOT}/scripts/lib-cloud-guard.sh"
+if [[ -r "$GUARD_LIB" ]]; then
+    # shellcheck source=lib-cloud-guard.sh
+    source "$GUARD_LIB"
+    if cloud_session; then
+        echo "bd-create-checked: refusing to create in cloud read-only mode." >&2
+        echo "  Beads writes don't survive the ephemeral container — note the candidate" >&2
+        echo "  in the PR description and let the workstation file it." >&2
+        echo "  (Override: bash scripts/install-bd-cloud.sh && bd create ...)" >&2
+        exit 1
+    fi
+fi
+
 if [[ "${BD_DUP_CHECK_SKIP:-0}" == "1" ]]; then
     exec bd create "$@"
 fi

--- a/scripts/bd-grep.sh
+++ b/scripts/bd-grep.sh
@@ -8,12 +8,14 @@
 # Usage:
 #   bash scripts/bd-grep.sh <keyword>                   # full-text search
 #   bash scripts/bd-grep.sh -p <0-4>                    # filter by priority
-#   bash scripts/bd-grep.sh -s <open|in_progress|done>  # filter by status
-#   bash scripts/bd-grep.sh -t <bug|feature|epic|...>   # filter by issue_type
+#   bash scripts/bd-grep.sh -s <open|in_progress|done|deferred|wont_fix|closed>
+#   bash scripts/bd-grep.sh -t <bug|feature|epic|...>   # case-insensitive
 #   bash scripts/bd-grep.sh <keyword> -p 0 -s open      # combine
+#   bash scripts/bd-grep.sh <keyword> --title-only      # tighter haystack
 #
 # Output: one line per matching issue — `<id>  [<status>]  <title>`.
-# Sorted by priority asc, then id asc. Limited to 50 hits unless --all.
+# Sorted by priority asc, then id asc (case-folded). Limited to 50 hits
+# unless --all. Truncation is announced on stdout when it happens.
 
 set -euo pipefail
 
@@ -23,11 +25,36 @@ if [[ ! -f "$JSONL" ]]; then
     exit 1
 fi
 
+VALID_STATUSES="open in_progress done deferred wont_fix closed blocked"
+
+usage() {
+    cat <<'USAGE'
+bd-grep.sh — read-only search across .beads/issues.jsonl
+
+Usage:
+  bash scripts/bd-grep.sh <keyword>                # full-text search
+  bash scripts/bd-grep.sh -p <0-4>                 # filter by priority
+  bash scripts/bd-grep.sh -s <status>              # filter by status
+  bash scripts/bd-grep.sh -t <issue_type>          # case-insensitive
+  bash scripts/bd-grep.sh <kw> -p 0 -s open        # combine
+  bash scripts/bd-grep.sh <kw> --title-only        # tighter haystack
+  bash scripts/bd-grep.sh <kw> --all               # no 50-hit cap
+
+Valid status values: open in_progress done deferred wont_fix closed blocked
+Valid priority values: 0 1 2 3 4 (P0=highest, P4=lowest)
+
+Output: <id>  [<status>]  <title>
+Sorted by priority asc, then id asc (case-folded). Limited to 50 hits
+unless --all; truncation is announced on stdout.
+USAGE
+}
+
 keyword=""
 priority=""
 status=""
 itype=""
 limit=50
+title_only=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -35,16 +62,37 @@ while [[ $# -gt 0 ]]; do
         -s) status="$2"; shift 2 ;;
         -t) itype="$2"; shift 2 ;;
         --all) limit=0; shift ;;
-        -h|--help) sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        --title-only) title_only=1; shift ;;
+        -h|--help) usage; exit 0 ;;
         *) if [[ -z "$keyword" ]]; then keyword="$1"; else echo "bd-grep: unexpected arg '$1'" >&2; exit 2; fi; shift ;;
     esac
 done
 
-python3 - "$JSONL" "$keyword" "$priority" "$status" "$itype" "$limit" <<'PY'
-import json, sys, re
-path, keyword, priority, status, itype, limit = sys.argv[1:7]
+# Validate priority — silent "0 hits" on an invalid value is the wrong UX.
+if [[ -n "$priority" && ! "$priority" =~ ^[0-4]$ ]]; then
+    echo "bd-grep: priority must be 0-4 (got '$priority')" >&2
+    exit 2
+fi
+
+# Validate status — accept any of the known values.
+if [[ -n "$status" ]]; then
+    matched=0
+    for s in $VALID_STATUSES; do
+        [[ "$status" == "$s" ]] && { matched=1; break; }
+    done
+    if [[ "$matched" -eq 0 ]]; then
+        echo "bd-grep: status must be one of: $VALID_STATUSES (got '$status')" >&2
+        exit 2
+    fi
+fi
+
+python3 - "$JSONL" "$keyword" "$priority" "$status" "$itype" "$limit" "$title_only" <<'PY'
+import json, sys
+path, keyword, priority, status, itype, limit, title_only = sys.argv[1:8]
 limit = int(limit)
+title_only = title_only == "1"
 kw = keyword.lower() if keyword else None
+itype_lc = itype.lower() if itype else None
 hits = []
 with open(path, encoding="utf-8") as f:
     for line in f:
@@ -55,26 +103,39 @@ with open(path, encoding="utf-8") as f:
             o = json.loads(line)
         except json.JSONDecodeError:
             continue
+        # Skip session-memory rows emitted by bd's auto-memory feature
+        # (not real issues; they show up with _type=memory).
         if o.get("_type") == "memory":
             continue
         if priority and str(o.get("priority", "")) != priority:
             continue
         if status and o.get("status", "") != status:
             continue
-        if itype and o.get("issue_type", "") != itype:
+        if itype_lc and (o.get("issue_type", "") or "").lower() != itype_lc:
             continue
         if kw:
-            blob = " ".join(str(o.get(k, "")) for k in ("id","title","description")).lower()
+            if title_only:
+                blob = str(o.get("title", "")).lower()
+            else:
+                blob = " ".join(str(o.get(k, "")) for k in ("id","title","description")).lower()
             if kw not in blob:
                 continue
         hits.append(o)
-hits.sort(key=lambda o: (o.get("priority", 9), o.get("id", "")))
-if limit > 0:
+# Case-fold the id sort key so Sylveste-906 doesn't lead sylveste-22oi.
+hits.sort(key=lambda o: (o.get("priority", 9), (o.get("id") or "").lower()))
+total = len(hits)
+if limit > 0 and total > limit:
     hits = hits[:limit]
+    truncated = True
+else:
+    truncated = False
 for o in hits:
     iid = o.get("id", "?")
     st = (o.get("status") or "?")[:11]
     title = (o.get("title") or "").replace("\n", " ")
     print(f"{iid:18s}  [{st:11s}]  {title[:90]}")
-print(f"-- {len(hits)} hit{'s' if len(hits)!=1 else ''}", file=sys.stderr)
+if truncated:
+    # Stdout-visible so it isn't lost in pipelines.
+    print(f"-- showing {limit}/{total} hits — pass --all to see the rest")
+print(f"-- {total} hit{'s' if total!=1 else ''}", file=sys.stderr)
 PY

--- a/scripts/check_beads_jsonl_dolt_sync.py
+++ b/scripts/check_beads_jsonl_dolt_sync.py
@@ -113,6 +113,23 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # Cloud-guard: this script asks Dolt for issue ids and compares to JSONL.
+    # In cloud there is no Dolt, and we treat JSONL as the source of truth,
+    # so the comparison is meaningless. Skip cleanly with exit 0.
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    try:
+        from lib_cloud_guard import cloud_session, cloud_log_skip, workstation_log_missing_bd
+    except ImportError:
+        cloud_session = lambda: False  # type: ignore
+        cloud_log_skip = lambda op="op": None  # type: ignore
+        workstation_log_missing_bd = lambda op="op": None  # type: ignore
+    if cloud_session():
+        cloud_log_skip("check_beads_jsonl_dolt_sync")
+        return 0
+    if shutil.which("bd") is None:
+        workstation_log_missing_bd("check_beads_jsonl_dolt_sync")
+        return 0
+
     args = build_parser().parse_args(argv)
     repo = args.repo.resolve()
     issues_jsonl = args.issues_jsonl or (repo / ".beads" / "issues.jsonl")

--- a/scripts/install-bd-cloud.sh
+++ b/scripts/install-bd-cloud.sh
@@ -10,30 +10,56 @@
 # Idempotent: skips work if both binaries are already at the expected
 # versions. Cost when binaries are absent: ~3s (download + extract).
 #
+# Linux-only. Refuses to install on darwin/freebsd/windows because the URL
+# template is hard-coded for linux releases and a downloaded ELF would
+# silently fail at exec time.
+#
+# Security: SHA256 verified after download. The bd archive is checked against
+# the upstream publisher's checksums.txt (one fetch per install). The dolt
+# archive is checked against a constant pinned in this file (dolt's upstream
+# does not publish a signed checksums file). Override via *_SHA256_* env
+# vars; mismatch fails closed.
+#
 # Usage:
 #   bash scripts/install-bd-cloud.sh
 #
-# Override versions:
-#   BD_VERSION=1.0.5 DOLT_VERSION=2.1.0 bash scripts/install-bd-cloud.sh
+# Override versions or checksums:
+#   BD_VERSION=1.0.5 DOLT_VERSION=2.1.0 \
+#   DOLT_SHA256_AMD64=<expected-hex> \
+#   bash scripts/install-bd-cloud.sh
 
 set -euo pipefail
 
 BD_VERSION="${BD_VERSION:-1.0.4}"
 DOLT_VERSION="${DOLT_VERSION:-2.0.4}"
-INSTALL_DIR="${INSTALL_DIR:-/root/.local/bin}"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+
+# Pinned checksums for the default versions. If you bump *_VERSION above,
+# either update these or pass *_SHA256_* via env. Mismatch is fail-closed.
+PINNED_DOLT_SHA256_AMD64_v2_0_4="d5a1924b164c6f25d30b9134f914669913397d706c0ccad1b17623343426728c"
 
 log() { echo "install-bd-cloud: $*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+[[ "$(uname -s)" == "Linux" ]] || die "Linux-only installer (uname=$(uname -s)); refusing"
 
 want_arch() {
     case "$(uname -m)" in
         x86_64|amd64) echo amd64 ;;
         aarch64|arm64) echo arm64 ;;
-        *) log "unsupported arch: $(uname -m)"; exit 1 ;;
+        *) die "unsupported arch: $(uname -m)" ;;
     esac
 }
 
 ARCH=$(want_arch)
 mkdir -p "$INSTALL_DIR"
+
+verify_sha256() {
+    local file="$1" expected="$2"
+    local actual
+    actual=$(sha256sum "$file" 2>/dev/null | awk '{print $1}')
+    [[ "$actual" == "$expected" ]] || die "sha256 mismatch on $file (expected=$expected actual=$actual)"
+}
 
 install_bd() {
     if command -v bd >/dev/null 2>&1; then
@@ -44,17 +70,30 @@ install_bd() {
             return 0
         fi
     fi
-    local url="https://github.com/gastownhall/beads/releases/download/v${BD_VERSION}/beads_${BD_VERSION}_linux_${ARCH}.tar.gz"
+    local base="https://github.com/gastownhall/beads/releases/download/v${BD_VERSION}"
+    local asset="beads_${BD_VERSION}_linux_${ARCH}.tar.gz"
     local tmp
     tmp=$(mktemp -d)
-    log "downloading bd $BD_VERSION ($url)"
-    if ! curl -fsSL --max-time 30 -o "$tmp/bd.tar.gz" "$url"; then
-        log "bd download failed"; rm -rf "$tmp"; return 1
+    trap 'rm -rf "$tmp"' RETURN
+
+    log "downloading bd $BD_VERSION ($base/$asset)"
+    curl -fsSL --max-time 60 -o "$tmp/$asset" "$base/$asset" \
+        || die "bd download failed"
+
+    # Verify against the upstream-published checksums.txt unless overridden.
+    local expected="${BD_SHA256:-}"
+    if [[ -z "$expected" ]]; then
+        log "fetching upstream checksums.txt for verification"
+        curl -fsSL --max-time 30 -o "$tmp/checksums.txt" "$base/checksums.txt" \
+            || die "checksums.txt download failed (network or upstream removed it)"
+        expected=$(awk -v a="$asset" '$2==a {print $1}' "$tmp/checksums.txt")
+        [[ -n "$expected" ]] || die "asset $asset not found in upstream checksums.txt"
     fi
-    tar -xzf "$tmp/bd.tar.gz" -C "$tmp"
+    verify_sha256 "$tmp/$asset" "$expected"
+
+    tar -xzf "$tmp/$asset" -C "$tmp"
     install -m 0755 "$tmp/bd" "$INSTALL_DIR/bd"
-    rm -rf "$tmp"
-    log "installed bd → $INSTALL_DIR/bd"
+    log "installed bd → $INSTALL_DIR/bd (sha256 ok)"
 }
 
 install_dolt() {
@@ -62,18 +101,43 @@ install_dolt() {
         log "dolt already installed at $(command -v dolt)"
         return 0
     fi
-    local url="https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}/dolt-linux-${ARCH}.tar.gz"
+    local base="https://github.com/dolthub/dolt/releases/download/v${DOLT_VERSION}"
+    local asset="dolt-linux-${ARCH}.tar.gz"
     local tmp
     tmp=$(mktemp -d)
-    log "downloading dolt $DOLT_VERSION ($url)"
-    if ! curl -fsSL --max-time 30 -o "$tmp/dolt.tar.gz" "$url"; then
-        log "dolt download failed"; rm -rf "$tmp"; return 1
-    fi
-    tar -xzf "$tmp/dolt.tar.gz" -C "$tmp"
+    trap 'rm -rf "$tmp"' RETURN
+
+    log "downloading dolt $DOLT_VERSION ($base/$asset)"
+    curl -fsSL --max-time 60 -o "$tmp/$asset" "$base/$asset" \
+        || die "dolt download failed"
+
+    # Dolt upstream does not publish a checksums file. Verify against the
+    # constant pinned in this file (or env override).
+    local expected=""
+    case "$ARCH" in
+        amd64)
+            if [[ "$DOLT_VERSION" == "2.0.4" ]]; then
+                expected="${DOLT_SHA256_AMD64:-$PINNED_DOLT_SHA256_AMD64_v2_0_4}"
+            else
+                expected="${DOLT_SHA256_AMD64:-}"
+            fi
+            ;;
+        arm64)
+            expected="${DOLT_SHA256_ARM64:-}"
+            ;;
+    esac
+    [[ -n "$expected" ]] || die "no pinned sha256 for dolt $DOLT_VERSION/$ARCH; set DOLT_SHA256_${ARCH^^}"
+    verify_sha256 "$tmp/$asset" "$expected"
+
+    tar -xzf "$tmp/$asset" -C "$tmp"
     install -m 0755 "$tmp/dolt-linux-${ARCH}/bin/dolt" "$INSTALL_DIR/dolt"
-    rm -rf "$tmp"
-    log "installed dolt → $INSTALL_DIR/dolt"
+    log "installed dolt → $INSTALL_DIR/dolt (sha256 ok)"
 }
 
 install_bd
 install_dolt
+
+# Surface PATH state so the caller knows whether `bd` is actually invocable.
+if ! command -v bd >/dev/null 2>&1; then
+    log "WARN: $INSTALL_DIR is not on PATH — add: export PATH=\"$INSTALL_DIR:\$PATH\""
+fi

--- a/scripts/lib-cloud-guard.sh
+++ b/scripts/lib-cloud-guard.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# lib-cloud-guard.sh — sourceable detection for Claude Code remote (cloud)
+# environments. Used by every script that invokes `bd` so they degrade the
+# same way: cleanly + read-only on cloud, loudly + actionably on workstation.
+#
+# Usage (from a calling script):
+#
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/lib-cloud-guard.sh"
+#
+#   if cloud_session; then
+#       cloud_log_skip "audit-roadmap-beads"
+#       exit 0
+#   fi
+#
+#   if ! command -v bd >/dev/null 2>&1; then
+#       workstation_log_missing_bd "audit-roadmap-beads"
+#       exit 0
+#   fi
+#
+# Detection: we treat the environment as "cloud" iff Claude Code's documented
+# remote-env signals are set. We deliberately do NOT use `command -v bd` as
+# a cloud proxy — a workstation with a temporarily broken PATH would be
+# misdiagnosed and the actual bug (broken PATH) would be hidden behind a
+# misleading "cloud mode" message. See PR #19 follow-up review.
+
+# Returns 0 if the current shell is a Claude Code cloud_default session.
+cloud_session() {
+    [[ "${CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE:-}" == cloud_default ]] && return 0
+    [[ "${IS_SANDBOX:-}" == "yes" ]] && return 0
+    return 1
+}
+
+# One-line stderr message: "cloud read-only mode, skipping <op>". Use when the
+# guard wants to no-op a bd-dependent operation in a cloud session.
+cloud_log_skip() {
+    local op="${1:-operation}"
+    echo "${op}: cloud read-only mode (CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE=${CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE:-unset}, IS_SANDBOX=${IS_SANDBOX:-unset}) — skipping bd-dependent path" >&2
+}
+
+# One-line stderr message: "bd missing on workstation, this is a real bug".
+# Use when the guard determines the environment is NOT cloud but bd is still
+# absent from PATH. Distinct message so the diagnostic is actionable.
+workstation_log_missing_bd() {
+    local op="${1:-operation}"
+    echo "${op}: bd not on PATH (and not a cloud session) — install bd (https://github.com/gastownhall/beads) or fix your PATH" >&2
+}

--- a/scripts/lib_cloud_guard.py
+++ b/scripts/lib_cloud_guard.py
@@ -1,0 +1,55 @@
+"""lib_cloud_guard — Python sibling of lib-cloud-guard.sh.
+
+Used by Python scripts that invoke `bd` so they degrade the same way:
+cleanly + read-only on cloud, loudly + actionably on workstation.
+
+Usage:
+
+    from lib_cloud_guard import cloud_session, cloud_log_skip, workstation_log_missing_bd
+    import shutil, sys
+
+    if cloud_session():
+        cloud_log_skip("backfill-bead-labels")
+        sys.exit(0)
+
+    if shutil.which("bd") is None:
+        workstation_log_missing_bd("backfill-bead-labels")
+        sys.exit(0)
+
+Detection mirrors the bash lib: env vars only, never `which bd`. See
+lib-cloud-guard.sh for rationale.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+
+def cloud_session() -> bool:
+    """True iff the current process is in a Claude Code cloud_default session."""
+    if os.environ.get("CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE") == "cloud_default":
+        return True
+    if os.environ.get("IS_SANDBOX") == "yes":
+        return True
+    return False
+
+
+def cloud_log_skip(op: str = "operation") -> None:
+    """Stderr message: cloud read-only mode, skipping a bd-dependent op."""
+    rem = os.environ.get("CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE", "unset")
+    sb = os.environ.get("IS_SANDBOX", "unset")
+    print(
+        f"{op}: cloud read-only mode "
+        f"(CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE={rem}, IS_SANDBOX={sb}) "
+        f"— skipping bd-dependent path",
+        file=sys.stderr,
+    )
+
+
+def workstation_log_missing_bd(op: str = "operation") -> None:
+    """Stderr message: bd is missing on a workstation (not cloud). Actionable."""
+    print(
+        f"{op}: bd not on PATH (and not a cloud session) — "
+        f"install bd (https://github.com/gastownhall/beads) or fix your PATH",
+        file=sys.stderr,
+    )

--- a/scripts/session-freshness-gate.sh
+++ b/scripts/session-freshness-gate.sh
@@ -74,10 +74,22 @@ if [[ -f "$CANDIDATE" ]]; then
     MEMORY_PATH="$CANDIDATE"
 fi
 
+# Container/host runtime epoch — the freshness manifest is otherwise blind to
+# runtime state (Dolt liveness, ephemeral container resets). boot_id flips on
+# every new cloud container, forcing a stale-classify on the first session
+# of a new container regardless of content hashes. Cheap, decisive, closes
+# the biggest observability gap in the estimator (PR #19 follow-up review,
+# control-theoretic + mission-command convergence).
+BOOT_ID=""
+if [[ -r /proc/sys/kernel/random/boot_id ]]; then
+    BOOT_ID=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null || true)
+fi
+
 # Compose the manifest: orientation files + synthetic keys.
 current=$(freshness_compute_manifest_paths "${ORIENTATION_FILES[@]}" ${MEMORY_PATH:+"$MEMORY_PATH"})
 [[ -n "$GIT_SHA" ]]   && current=$(echo "$current" | freshness_add_key git_sha   "$GIT_SHA")
 [[ -n "$BEADS_SHA" ]] && current=$(echo "$current" | freshness_add_key beads_sha "$BEADS_SHA")
+[[ -n "$BOOT_ID" ]]   && current=$(echo "$current" | freshness_add_key boot_id   "$BOOT_ID")
 
 # ─── Compare to saved ──────────────────────────────────────────────────
 

--- a/scripts/sync-roadmap-json.sh
+++ b/scripts/sync-roadmap-json.sh
@@ -7,6 +7,23 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ROOT_DOCS_DIR="$ROOT_DIR/docs"
 OUTPUT="${1:-$ROOT_DOCS_DIR/roadmap.json}"
 
+# Cloud-guard: bd is unavailable in cloud sessions; this script would emit
+# warnings and produce a roadmap.json with all bead links missing. Skip
+# cleanly instead.
+GUARD_LIB="$ROOT_DIR/scripts/lib-cloud-guard.sh"
+if [[ -r "$GUARD_LIB" ]]; then
+    # shellcheck source=lib-cloud-guard.sh
+    source "$GUARD_LIB"
+    if cloud_session; then
+        cloud_log_skip "sync-roadmap-json"
+        exit 0
+    fi
+    if ! command -v bd >/dev/null 2>&1; then
+        workstation_log_missing_bd "sync-roadmap-json"
+        exit 0
+    fi
+fi
+
 # Read project config from .interwatch/project.yaml if available
 _PROJECT_YAML="$ROOT_DIR/.interwatch/project.yaml"
 if [ -z "${ROADMAP_PROJECT:-}" ] && [ -f "$_PROJECT_YAML" ] && command -v yq >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Follow-up to #19 implementing the P0/P1 + damage-isolation findings from the multi-track flux-review. Cross-track convergences (adjacent + control-theoretic + mission-command) drove the prioritization.

### What it fixes

| Finding (track / severity) | Fix |
|---|---|
| Cloud-detection-as-`command -v bd` (adjacent P1 + mission-command P1, 2/3 convergence) | New `scripts/lib-cloud-guard.sh` + `.py` — single source of truth; uses documented env vars; distinct messages for cloud vs missing-bd-on-workstation |
| Freshness gate blind to runtime state (control P1 + mission-command P1, 2/3 convergence) | Add `/proc/sys/kernel/random/boot_id` to the manifest — every new container forces stale-classify |
| `install-bd-cloud.sh` has no SHA256 verification (adjacent P1, security) | Verify bd against upstream `checksums.txt`, verify dolt against pinned constant; fail closed on mismatch; Linux-only guard |
| `bd-grep` input validation (adjacent P1) | Validate `-p ^[0-4]$`, validate `-s` against enum, case-insensitive `-t`, case-folded ID sort, explicit `--help`, stdout truncation announcement, `--title-only` flag |
| Damage isolation (mission-command P2) | Apply guard to `audit-roadmap-beads.sh`, `sync-roadmap-json.sh`, `backfill-bead-labels.py`, `check_beads_jsonl_dolt_sync.py`, `bd-create-checked.sh` (latter refuses loudly) |
| heal-dolt has no anytime budget + readiness gap (control P2 × 2) | `timeout ${HEAL_DOLT_BUDGET_S:-5} bd dolt start`; post-start poll `bd stats` until ready or 2s; closed-loop wait on kill_orphans replaces `sleep 1`; SIGKILL stragglers; PID parse guard |
| PreCompact uses empty matcher (adjacent P2) | Tightened to `"manual"` — only `/compact` fires, not auto-compaction |
| PRIME.md over-skips git workflow (adjacent P3 + mission-command P2) | Reworded to "Skip the **bd CLI steps below**" |

### Validated end-to-end

- Cloud detection: both `CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE=cloud_default` and `IS_SANDBOX=yes` correctly trigger read-only mode with a one-line stderr.
- Workstation-missing-bd: emits a distinct actionable message ("install bd or fix your PATH") rather than the misleading "cloud read-only mode".
- `install-bd-cloud` SHA verification: passes for the real upstream binaries, fails closed on `BD_SHA256=deadbeef` override.
- `install-bd-cloud` Linux-only guard: refuses on simulated Darwin.
- `bd-grep -p 5`, `-p high`, `-s bogus`: all return rc=2 with helpful errors.
- `bd-grep -t Bug`: case-insensitive match returns results (previously 0).
- `bd-grep -s open`: shows "-- showing 50/364 hits — pass --all to see the rest" on stdout.
- `boot_id` is present in `.claude/session-state.json` after a stale run.
- All 6 bd-invoking scripts: skip/refuse appropriately in a simulated cloud session.
- Full hook chain end-to-end in fresh state: 122 ms, one clean log line.

### What's deferred (intentionally)

- **Telemetry** (control P3 + mission-command P3) — appending invocation logs to `.claude/session-state.log`. Worth doing once we have a reason to tune. Not load-bearing right now.
- **Sub-agent initiative escalation** (mission-command P1) — the CLAUDE.md doctrine about when an agent may run `install-bd-cloud.sh` autonomously. Probably belongs in a separate doc commit, not a code PR.
- **Degraded-ops capability table** in heal-dolt header (mission-command P2) — descriptive doc-only.
- **"sync footgun" rationale parenthetical** in CLAUDE.md (mission-command P3) — single-token-cost item, skipped to keep the PR focused.

## Test plan

- [ ] Spin up a fresh `cloud_default` container, confirm one-line `cloud read-only mode` log
- [ ] On the workstation with bd installed, confirm `heal-dolt` runs its full Dolt path normally (3-way branch falls through to nominal)
- [ ] On a workstation with bd intentionally not in PATH, confirm `heal-dolt` emits the actionable "install bd or fix PATH" message (not the misleading cloud message)
- [ ] If you ever run `bash scripts/install-bd-cloud.sh` in cloud, confirm both downloads are SHA-verified before extraction (look for "sha256 ok" lines)


---
_Generated by [Claude Code](https://claude.ai/code/session_01757BLMrimgB2hP5ZrGTLLJ)_