### PR TITLE
Step 2 introspection-probe scaffold + Step 3 Jetty design spike

### DIFF
--- a/.github/workflows/introspection-probe.yml
+++ b/.github/workflows/introspection-probe.yml
@@ -1,0 +1,39 @@
+name: Introspection probe
+
+on:
+  push:
+    paths:
+      - ".github/workflows/introspection-probe.yml"
+      - "experiments/introspection-probe/**"
+      # the probe reuses calibration-eval's metrics by path, so changes there can affect it
+      - "experiments/calibration-eval/src/metrics.py"
+  pull_request:
+    paths:
+      - ".github/workflows/introspection-probe.yml"
+      - "experiments/introspection-probe/**"
+      - "experiments/calibration-eval/src/metrics.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: experiments/introspection-probe
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install (CPU-only; the [interp] extra with nnsight/torch stays off CI)
+        run: |
+          uv venv
+          uv pip install -e ".[dev]"
+
+      - name: Unit tests (probe decode, dissociation, steering direction, metric bridge)
+        run: uv run pytest

--- a/experiments/agentic-metacognition/DESIGN.md
+++ b/experiments/agentic-metacognition/DESIGN.md
@@ -1,0 +1,147 @@
+# Agentic Metacognition (Step 3) — design spike
+
+> **Question:** can an agent act on *self-assessed competence* — abstain, escalate,
+> ask-for-help, or route — instead of answering at a fixed confidence, and does that
+> measurably beat answer-everything?
+>
+> Status: **design spike.** This is the ROADMAP's Step 3, deliberately sequenced *after*
+> Step 2 yields a usable uncertainty signal. Nothing here runs yet. The spike's job is to
+> decide **what Jetty should and should not own** before any build.
+
+---
+
+## 1. Where this sits in the program
+
+From `../calibration-eval/ROADMAP.md`: Step 1 (behavioral sensitivity eval) is shipped;
+Step 2 (`../introspection-probe`, mechanistic — does an internal uncertainty signal
+exist and is the report grounded in it?) is next. **Step 3 is parked until Step 2 yields a
+usable signal to drive the policy.** That dependency is real: an abstain/escalate policy is
+only as good as the competence estimate it acts on, and Step 1 already showed stated
+confidence is an inefficient estimate (M-ratio < 1 everywhere). Step 2 is the search for a
+*better* signal; Step 3 is putting whichever signal wins into a control loop.
+
+## 2. The Jetty question, answered
+
+**Can Jetty own "much of this work"? No — but it owns Step 3 cleanly, and that was always
+the plan.** The split is load-bearing, so it's worth stating precisely.
+
+### What Jetty is (verified against docs.jetty.io, 2026-06)
+
+An LLM-eval **orchestration** substrate: JSON-defined "agentic workflow" runbooks of named
+steps with path-based trajectory access. Relevant steps:
+
+- **`simple_judge`** — LLM-as-judge in *categorical/binary* or *scale* mode (returns
+  judgment/score + reasoning + aggregates), LiteLLM under the hood (100+ providers incl.
+  Anthropic/OpenAI/Gemini).
+- **`litellm_chat`** — generation before evaluation.
+- **`select_trajectories`** / **`extract_from_trajectories`** — filter inputs / pull outputs
+  from child workflows.
+- **`list_emit_await`** — fan out over a list (e.g. scenario × model pairs) with parallel
+  child activities, then collect.
+- correlation/calibration visualization (judge-vs-human) — the basis of the
+  Spearman-gate pattern already used in Auraken's eval (`sylveste-lfdy.1`).
+
+### Why it does NOT belong in Steps 1-2 (the confound)
+
+- **Step 1 scoring is deterministic with ground truth** — MC modal-answer, numeric GSM8K,
+  type-2 AUROC/meta-d′. Inserting `simple_judge` to grade correctness would add a second
+  model's noise where the answer is *known*. Wrong tool.
+- **Jetty's signature is the refine-until-passes loop.** Steps 1-2 measure *the model's own*
+  uncertainty signal; wrap it in a check-your-work loop and you measure the harness, not the
+  model. That is exactly the confound the ROADMAP excludes.
+- **Step 2 is mechanistic interp** (residual-stream probes, steering). Jetty operates on
+  text I/O and trajectories — it cannot read or steer activations. Zero overlap with
+  nnsight/transformer-lens.
+- Step 1's matrix parallelism is already handled by Inspect + `run_matrix.sh`; Jetty on top
+  would be redundant orchestration.
+
+### Why it DOES belong in Step 3
+
+In Step 3 the **self-monitoring loop is the object of study, not a confound.** An agent that
+abstains/escalates/routes *is* a check-your-competence loop; `list_emit_await` over
+(item × policy) with child activities for the act/score cycle is a natural fit, and
+`extract_from_trajectories` + the correlation tooling give the policy-vs-baseline
+aggregation and the judge-calibration gate for free. Reusing the same substrate Auraken
+already runs (`sylveste-lfdy.1`) is comparative-advantage, not new infra.
+
+## 3. Architecture (proposed)
+
+Three layers, kept separate so the measurement stays clean:
+
+| Layer | Role | Tech |
+|---|---|---|
+| **Competence signal** | per-item P(correct) estimate the policy acts on | verbalized conf (Step 1), and/or the Step-2 internal probe signal once it exists |
+| **Policy** | maps signal → action: `answer` / `abstain` / `escalate` / `ask` / `route` | thin, deterministic; thresholds tuned on a held-out split |
+| **Harness (Jetty)** | drive item × policy, run the act/score cycle, aggregate, calibrate | Jetty runbooks |
+
+The competence signal is **imported, not invented here** — that is the whole reason Step 3
+waits on Step 2. The policy is deliberately simple (the research is in *whether acting on
+the signal pays*, not in a clever policy). Jetty is harness-only.
+
+### Outcome metrics
+
+- **Risk-coverage / selective-prediction curve:** accuracy on answered items vs coverage
+  (fraction answered) as the abstention threshold sweeps. Headline: does acting on the
+  competence signal dominate answer-everything and a random-abstention baseline?
+- **Value under an asymmetric payoff:** reward correct, penalize wrong, small cost to
+  escalate/ask — does the policy beat fixed-confidence answering at realistic cost ratios?
+- **Escalation precision:** of items routed up, how many the model would actually have
+  gotten wrong (uses Step-1/2 ground-truth labels — deterministic, no judge needed).
+
+`simple_judge` enters only where an action's *output* has no ground truth (e.g. grading the
+quality of a clarifying question the agent asks) — and there it goes through the same
+human-correlation calibration gate (Spearman ≥ 0.7) before any score is trusted, mirroring
+`sylveste-lfdy.1`.
+
+## 4. Runbook sketch (illustrative, not yet built)
+
+```jsonc
+// tests/evals/agentic-metacog/risk-coverage.runbook.json  (sketch)
+{
+  "name": "risk_coverage_sweep",
+  "steps": [
+    { "step": "list_emit_await",            // fan out over items × thresholds
+      "over": "items",
+      "child": {
+        "steps": [
+          { "step": "litellm_chat", "as": "answer" },        // model answers + states competence signal
+          { "step": "policy_gate",                            // custom: signal -> action (answer/abstain/escalate)
+            "signal": "$answer.competence", "thresholds": "$thresholds" }
+        ] } },
+    { "step": "extract_from_trajectories", "path": "$..action", "as": "actions" },
+    { "step": "risk_coverage_curve",        // accuracy@coverage vs ground-truth labels (deterministic)
+      "labels": "calibration-eval/runs/labels.parquet" }
+  ]
+}
+```
+
+`policy_gate` and `risk_coverage_curve` are the only custom steps; everything else is stock
+Jetty. The ground-truth labels come straight from the Step-1 logs, so the *scoring* of the
+policy is judge-free — Jetty only orchestrates the act/route cycle.
+
+## 5. Adjacent study Jetty unlocks for free: judge self-knowledge
+
+Jetty's judge-calibration machinery is itself a *calibration measurement*. A distinct,
+Jetty-native metacognition question: **does an LLM-judge know when its own verdicts are
+unreliable?** Have `simple_judge` emit a confidence alongside each score; compute the
+judge's type-2 sensitivity (reuse `calibration-eval/src/metrics.py`) against human labels.
+This is the same "knows what it knows" instrument pointed at the *evaluator* instead of the
+answerer — cheap, uses infrastructure Auraken already needs (`sylveste-lfdy.1`), and could
+run before Step 2 finishes since it needs no interp.
+
+## 6. Dependencies & open questions
+
+- **Blocks on Step 2** for the *internal*-signal policy arm. A verbalized-signal-only
+  version of Step 3 could run earlier, but it would inherit Step 1's known inefficiency —
+  worth it only as a baseline the internal signal must beat.
+- **Jetty maturity:** confirm `list_emit_await` + custom-step extensibility (`policy_gate`,
+  `risk_coverage_curve`) on the current Jetty before committing; the docs surface the step
+  catalog but custom-step ergonomics need a spike.
+- **Publishability:** ROADMAP flags Step 3 as "the fuzziest to make publishable quickly."
+  Risk-coverage with an asymmetric payoff is the most concrete framing; lead with that.
+- **Bead candidates (cloud session — beads read-only; for the workstation to file):**
+  - Step-3 spike: stand up one Jetty `risk_coverage` runbook on Step-1 verbalized signal as
+    the baseline (no Step-2 dependency).
+  - Judge-self-knowledge study (§5) — type-2 metrics on `simple_judge` confidence vs human
+    labels; reuses calibration-eval metrics + Auraken's Jetty wiring.
+  - Confirm Jetty custom-step extensibility for `policy_gate` / `risk_coverage_curve`.

--- a/experiments/introspection-probe/.gitignore
+++ b/experiments/introspection-probe/.gitignore
@@ -1,0 +1,16 @@
+# Python envs / caches
+.venv/
+uv.lock
+__pycache__/
+*.pyc
+.pytest_cache/
+.ipynb_checkpoints/
+*.egg-info/
+
+# Captured activations (regenerate on the GPU host; can be large) and run outputs
+activations/
+runs/*
+!runs/.gitkeep
+
+# Secrets (Tailscale auth key, HF token, etc.)
+.env

--- a/experiments/introspection-probe/PREREGISTRATION.md
+++ b/experiments/introspection-probe/PREREGISTRATION.md
@@ -1,0 +1,82 @@
+# Pre-registration — Introspection Probe (Step 2)
+
+> Locked **before** running activation capture on real weights. The design lives in
+> [`DESIGN.md`](DESIGN.md); this file fixes the falsifiable claims, the locus-selection
+> rule, and the controls so the analysis is not retrofitted to the data. Amendments after
+> first capture must be logged in the "Amendments" section with a date and reason.
+
+Status at lock time: GPU-independent analysis core (`src/probe.py`) implemented and tested
+(10 tests, CPU-only). Activation capture + steering (`capture_activations`,
+`steer_and_reelicit`) are interface stubs pending the GPU host (DESIGN §7). Behavioral
+seed: the merged Step-1 logs (`../calibration-eval`) supply per-item correctness and
+verbalized confidence.
+
+## Subjects & data
+
+- **Model tier:** a single small open-weight Hermes that fits the RTX 4090 in bf16
+  (~7-8B; DESIGN §7). The exact checkpoint is confirmed present on the NousResearch HF org
+  before locking the run (portal API access ≠ weight access). Mechanistic ladder is capped
+  at this tier — a known asymmetry vs the behavioral ladder.
+- **Items:** the same stimuli and correctness labels as Step 1 — `interest_domain.jsonl`
+  plus the public-benchmark items already scored — so the internal signal is evaluated on
+  exactly the behavioral footing.
+- **Locus (pre-registered):** read at the **answer-commitment token** (the token fixing the
+  MC letter). Secondary, reported separately, not part of the primary test: the
+  confidence-number token (reading vs writing the report). Layers: full sweep; the reported
+  primary locus is the **single layer with peak out-of-fold decoding AUROC on a held-out
+  split**, selected by `layer_sweep` under nested cross-validation (no double-dipping).
+
+## Hypotheses
+
+| ID | Link (DESIGN §3) | Claim | Falsifiable test | Primary statistic |
+|----|------|-------|------|------|
+| **H1** | Existence | An internal signal encodes the model's *own* correctness | out-of-fold probe type-2 AUROC > 0.5 after difficulty controls | `ProbeResult.auroc`, difficulty-partialled |
+| **H2** | Headroom | The internal signal knows more than the report says | `meta_d′(internal) > meta_d′(verbalized)` | paired bootstrap CI on the difference |
+| **H3** | Coupling | The report **reads from** the signal | steering shifts verbalized confidence monotonically in α | slope of stated-conf vs α, vs random-direction control |
+| **H4** | Domain | Grounding/headroom differ by `domain_type` | H1/H2 effect sizes vary across domains (ties to RQ2) | per-domain AUROC / meta-d′ gap |
+
+**H3 makes the null informative:** if the decodable signal shifts under steering but the
+report does not move, that *is* the finding — stated confidence is post-hoc/confabulated.
+H3 is not "supported vs failed"; it is "grounded vs confabulated."
+
+## Analysis plan
+
+1. **Capture** activations at the locus over all items, all layers (`capture_activations`).
+2. **H1:** `fit_confidence_probe` per layer (`layer_sweep`); pick the primary locus by peak
+   held-out AUROC; report AUROC with item-difficulty (per-item public-benchmark difficulty
+   / cross-model disagreement) partialled out.
+3. **H2:** put internal, verbalized, and (if available) logprob signals on one type-2 SDT
+   footing via `_calmetrics`; paired bootstrap over items for `meta_d′(internal) −
+   meta_d′(verbalized)`.
+4. **Dissociation set:** `dissociation_set(internal_conf, verbalized_conf)` → the Probe-C
+   focus items (internal-high/verbal-low and internal-low/verbal-high).
+5. **H3:** `confidence_direction` (diff-of-means, raw space) → `steer_and_reelicit` over an
+   α-grid at the primary layer; fit the stated-conf-vs-α slope on the dissociation set and
+   on the full set.
+6. **H4:** repeat H1/H2 within each `domain_type`.
+
+## Controls (preempt the reviewer — DESIGN §8)
+
+- **Difficulty leakage:** partial out item difficulty; prefer items where samples/models
+  disagree (own-uncertainty varies with input held fixed) so the probe cannot be reading
+  input difficulty alone.
+- **Double-dipping:** probe predictions are always out-of-fold; locus chosen on held-out
+  AUROC under nested CV; never fit and evaluate on the same items.
+- **Steering validity (H3):** norm-matched **random-direction** control (must do nothing);
+  capability sanity check (steering must not merely break the model); cross-check whether
+  the *answer* also changes (shared correctness signal vs report-only knob).
+- **Temporal ordering:** confidence is verbalized *after* the answer in the prompt, so the
+  answer-token signal genuinely precedes the report — supports a "leads/reads-from" reading
+  if H3 holds.
+
+## Decision rules
+
+- Headline sequence **H2 → H3** (DESIGN §11 Q3): H2 (headroom) is cheaper and already a
+  strong "knows more than it says" result; H3 (coupling) is the deeper but more
+  failure-prone grounding claim. Report H2 regardless of H3 outcome.
+- Effect sizes with bootstrap CIs over items; no NHST thresholds beyond the H1 chance
+  baseline. Per-domain cells inherit Step-1's small-n caveat — reported as directional.
+
+## Amendments
+
+_None yet. Log dated changes here if the plan changes after first capture._

--- a/experiments/introspection-probe/pyproject.toml
+++ b/experiments/introspection-probe/pyproject.toml
@@ -1,0 +1,34 @@
+[project]
+name = "introspection-probe"
+version = "0.1.0"
+description = "Is a model's stated confidence grounded in an internal uncertainty signal, or confabulated? (Step 2 flagship)"
+readme = "DESIGN.md"
+requires-python = ">=3.11"
+# The GPU-independent analysis core (probe fitting, dissociation, metric reuse) needs only
+# numpy. Activation capture + steering deps are isolated in the [interp] extra so CI and the
+# scaffold tests stay free, fast, and CPU-only.
+dependencies = [
+    "numpy>=1.26",
+]
+
+[project.optional-dependencies]
+# Installed only on the GPU host (desktop/WSL2) for capture_activations / steer_and_reelicit.
+interp = [
+    "nnsight>=0.3",
+    "torch>=2.2",
+    "transformers>=4.44",
+]
+dev = ["pytest>=8.0"]
+
+[tool.pytest.ini_options]
+# run `pytest` from the experiment root; lets tests do `from src.probe import ...` and lets
+# _calmetrics resolve the sibling calibration-eval/src/metrics.py by path.
+pythonpath = ["."]
+testpaths = ["tests"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]

--- a/experiments/introspection-probe/src/__init__.py
+++ b/experiments/introspection-probe/src/__init__.py
@@ -1,0 +1,8 @@
+"""Introspection probe (Step 2 flagship): is stated confidence grounded or confabulated?
+
+GPU-independent analysis core lives in ``probe.py`` and is unit-tested without nnsight or a
+GPU. See ``../DESIGN.md`` for the full grounding-chain design and ``../PREREGISTRATION.md``
+for the locked hypotheses and analysis plan.
+"""
+
+__all__ = ["probe"]

--- a/experiments/introspection-probe/src/_calmetrics.py
+++ b/experiments/introspection-probe/src/_calmetrics.py
@@ -1,0 +1,41 @@
+"""Bridge to the calibration-eval metrics (DESIGN.md §6 reuse bridge).
+
+The flagship scores the *internal* probe signal on the **exact same type-2 SDT footing**
+as the behavioral eval — type-2 AUROC, meta-d', M-ratio — so internal vs verbalized vs
+logprob discriminators are directly comparable (Probe B). Rather than re-implement or
+pip-install the sibling experiment (whose wheel package is the generic name ``src``, which
+would collide with this experiment's own ``src``), we load its ``metrics.py`` by path.
+
+This keeps the metric definitions in exactly one place: any fix to meta-d' over there is
+inherited here for free, and there is no second copy to drift.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+_METRICS_PATH = (
+    pathlib.Path(__file__).resolve().parents[2] / "calibration-eval" / "src" / "metrics.py"
+)
+
+if not _METRICS_PATH.exists():  # pragma: no cover - defensive, sibling-dir contract
+    raise ImportError(
+        f"calibration-eval metrics not found at {_METRICS_PATH}. The introspection probe "
+        "reuses them and expects the sibling experiment to be present in the monorepo."
+    )
+
+_spec = importlib.util.spec_from_file_location("calibration_eval_metrics", _METRICS_PATH)
+assert _spec and _spec.loader  # for type-checkers
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+# Re-export the type-2 panel used by the probe. ``scale`` arg is 100.0 for 0-100 verbalized
+# confidence and 1.0 for probabilities (the probe emits P(correct) in [0, 1]).
+auroc = _mod.auroc
+meta_d_prime = _mod.meta_d_prime
+m_ratio = _mod.m_ratio
+d_prime = _mod.d_prime
+summarize = _mod.summarize
+
+__all__ = ["auroc", "meta_d_prime", "m_ratio", "d_prime", "summarize"]

--- a/experiments/introspection-probe/src/probe.py
+++ b/experiments/introspection-probe/src/probe.py
@@ -1,0 +1,292 @@
+"""Internal-confidence probe — GPU-independent core of the introspection flagship.
+
+Implements the parts of the grounding-chain analysis (DESIGN.md §3-4) that need only
+captured activation arrays, so they are unit-testable with no GPU, no open weights, and
+no API:
+
+- ``fit_confidence_probe`` — the linear probe (Probe A / "Existence"): decode a model's
+  *own* per-item correctness from residual-stream activations. Returns **out-of-fold**
+  predictions so the reported decoding AUROC is honest (no train-on-test double-dipping,
+  DESIGN §8).
+- ``layer_sweep`` — fit the probe per layer; find where own-correctness becomes linearly
+  decodable (DESIGN Probe A, locus selection).
+- ``confidence_direction`` — the steering vector for Probe C (diff-of-means in raw
+  activation space; norm-matchable, the standard ActAdd construction).
+- ``dissociation_set`` — items where the internal signal and the verbalized report
+  disagree; the confabulation-candidate set that Probe C focuses on (DESIGN Probe B->C).
+
+Scoring reuses calibration-eval's type-2 SDT metrics (``_calmetrics``) so internal vs
+verbalized vs logprob signals sit on the same footing (Probe B / "Headroom").
+
+The two pieces that genuinely need nnsight + a GPU + open weights — ``capture_activations``
+and ``steer_and_reelicit`` — are interface stubs below. They run in the desktop/WSL2
+session (DESIGN §7); their signatures are fixed here so the analysis code above is written
+and tested against them now.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+from src._calmetrics import auroc, meta_d_prime, m_ratio
+
+
+# ---------------------------------------------------------------------------
+# Probe A — decode an internal correctness signal (representational)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ProbeResult:
+    """Output of a fitted confidence probe at one locus/layer."""
+
+    internal_conf: np.ndarray  # out-of-fold P(correct), aligned to input items, in [0,1]
+    weight: np.ndarray  # logistic weight in *standardized* feature space, shape [d_model]
+    bias: float  # logistic intercept (standardized space)
+    feat_mean: np.ndarray  # standardization mean, shape [d_model]
+    feat_std: np.ndarray  # standardization std (zeros mapped to 1), shape [d_model]
+    auroc: float  # type-2 AUROC of internal_conf vs correctness (out-of-fold)
+    meta_d_prime: float  # internal-signal meta-d' (out-of-fold)
+    m_ratio: float  # internal-signal M-ratio (out-of-fold)
+    n_folds: int
+
+
+def _sigmoid(z: np.ndarray) -> np.ndarray:
+    # numerically stable logistic
+    out = np.empty_like(z, dtype=float)
+    pos = z >= 0
+    out[pos] = 1.0 / (1.0 + np.exp(-z[pos]))
+    ez = np.exp(z[~pos])
+    out[~pos] = ez / (1.0 + ez)
+    return out
+
+
+def _standardize(
+    X: np.ndarray, mean: np.ndarray | None = None, std: np.ndarray | None = None
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    if mean is None:
+        mean = X.mean(axis=0)
+    if std is None:
+        std = X.std(axis=0)
+        std = np.where(std == 0.0, 1.0, std)
+    return (X - mean) / std, mean, std
+
+
+def _logreg_fit(
+    X: np.ndarray, y: np.ndarray, *, l2: float, lr: float, iters: int
+) -> tuple[np.ndarray, float]:
+    """L2-regularized logistic regression by full-batch gradient descent.
+
+    numpy-only (matches calibration-eval's scipy-free philosophy) and deterministic, so a
+    given (activations, labels) always yields the same probe — important for a
+    pre-registered analysis. The intercept is unregularized.
+    """
+    n, d = X.shape
+    w = np.zeros(d, dtype=float)
+    b = 0.0
+    for _ in range(iters):
+        p = _sigmoid(X @ w + b)
+        resid = p - y
+        grad_w = X.T @ resid / n + l2 * w / n
+        grad_b = float(resid.mean())
+        w -= lr * grad_w
+        b -= lr * grad_b
+    return w, b
+
+
+def _kfold_indices(n: int, n_folds: int, seed: int) -> list[np.ndarray]:
+    rng = np.random.default_rng(seed)
+    idx = rng.permutation(n)
+    return [fold for fold in np.array_split(idx, n_folds)]
+
+
+def fit_confidence_probe(
+    activations: np.ndarray,
+    correct: Sequence[float],
+    *,
+    l2: float = 1.0,
+    n_folds: int = 5,
+    lr: float = 0.5,
+    iters: int = 2000,
+    seed: int = 0,
+) -> ProbeResult:
+    """Fit a linear probe that decodes own-correctness from activations (Probe A).
+
+    ``activations`` is ``[n_items, d_model]`` captured at one locus/layer; ``correct`` is
+    the 0/1 correctness label per item (from the behavioral eval logs). Predictions are
+    produced **out-of-fold** (each item scored by a probe that did not see it), so
+    ``auroc`` is an honest held-out decoding estimate, not a fit statistic. The returned
+    ``weight``/``bias`` are then refit on *all* items for downstream use.
+
+    The reported meta-d'/M-ratio put the internal signal on the same type-2 SDT footing as
+    the verbalized report, enabling the headroom comparison (Probe B).
+    """
+    X = np.asarray(activations, dtype=float)
+    y = np.asarray(correct, dtype=float)
+    if X.ndim != 2:
+        raise ValueError(f"activations must be 2-D [n_items, d_model], got shape {X.shape}")
+    if X.shape[0] != y.shape[0]:
+        raise ValueError(f"activations/correct length mismatch: {X.shape[0]} vs {y.shape[0]}")
+    n = X.shape[0]
+    if n_folds < 2 or n_folds > n:
+        raise ValueError(f"n_folds must be in [2, n_items={n}], got {n_folds}")
+
+    folds = _kfold_indices(n, n_folds, seed)
+    oof = np.full(n, np.nan, dtype=float)
+    for test_idx in folds:
+        train_idx = np.setdiff1d(np.arange(n), test_idx, assume_unique=False)
+        Xtr, mean, std = _standardize(X[train_idx])
+        w, b = _logreg_fit(Xtr, y[train_idx], l2=l2, lr=lr, iters=iters)
+        Xte, _, _ = _standardize(X[test_idx], mean, std)
+        oof[test_idx] = _sigmoid(Xte @ w + b)
+
+    # full-data refit for the deployed probe weight/direction
+    Xall, mean, std = _standardize(X)
+    w_all, b_all = _logreg_fit(Xall, y, l2=l2, lr=lr, iters=iters)
+
+    return ProbeResult(
+        internal_conf=oof,
+        weight=w_all,
+        bias=b_all,
+        feat_mean=mean,
+        feat_std=std,
+        auroc=auroc(oof, y, scale=1.0),
+        meta_d_prime=meta_d_prime(oof, y, scale=1.0),
+        m_ratio=m_ratio(oof, y, scale=1.0),
+        n_folds=n_folds,
+    )
+
+
+def layer_sweep(
+    activations_by_layer: dict[int, np.ndarray],
+    correct: Sequence[float],
+    **probe_kwargs,
+) -> dict[int, ProbeResult]:
+    """Fit ``fit_confidence_probe`` at each layer; the basis for locus selection.
+
+    Returns ``{layer: ProbeResult}``. Read off the layer where decoding AUROC peaks (and,
+    with capture at the answer-commitment token, whether it peaks *before* the
+    verbalization tokens — the temporal-priority signal for headroom, DESIGN Probe A).
+    """
+    return {
+        layer: fit_confidence_probe(acts, correct, **probe_kwargs)
+        for layer, acts in sorted(activations_by_layer.items())
+    }
+
+
+def confidence_direction(
+    activations: np.ndarray,
+    correct: Sequence[float],
+    *,
+    high: float = 0.5,
+) -> np.ndarray:
+    """The steering vector for Probe C: diff-of-means in *raw* activation space.
+
+    ``mean(correct activations) - mean(incorrect activations)``. Kept in raw (un-
+    standardized) space so it can be added back to activations directly and norm-matched
+    against a random control (DESIGN §4 Probe C, §8 controls). ``high`` lets you split on
+    a graded internal-confidence array instead of the binary label by passing those values
+    as ``correct`` with a threshold.
+    """
+    X = np.asarray(activations, dtype=float)
+    c = np.asarray(correct, dtype=float)
+    hi = c >= high
+    lo = ~hi
+    if not hi.any() or not lo.any():
+        raise ValueError("need both high and low items to form a diff-of-means direction")
+    return X[hi].mean(axis=0) - X[lo].mean(axis=0)
+
+
+# ---------------------------------------------------------------------------
+# Probe B -> C — dissociation set (the confabulation-candidate items)
+# ---------------------------------------------------------------------------
+
+
+def dissociation_set(
+    internal_conf: Sequence[float],
+    verbalized_conf: Sequence[float],
+    *,
+    internal_scale: float = 1.0,
+    verbalized_scale: float = 100.0,
+    margin: float = 0.3,
+) -> dict[str, np.ndarray]:
+    """Items where the internal signal and the verbalized report disagree (DESIGN Probe B).
+
+    Both signals are mapped to [0, 1]. An item is flagged when they differ by more than
+    ``margin``. These are the highest-signal targets for the causal test (Probe C): if
+    steering the internal signal moves the report on exactly the items where they currently
+    diverge, that is the grounding evidence.
+
+    Returns index arrays:
+      - ``internal_high_verbal_low``: model "feels" right but reports low confidence
+        (introspective headroom the report fails to surface)
+      - ``internal_low_verbal_high``: model reports high confidence with no internal
+        support (confabulation candidates)
+      - ``either``: the union, the Probe-C focus set
+    """
+    iconf = np.clip(np.asarray(internal_conf, dtype=float) / internal_scale, 0.0, 1.0)
+    vconf = np.clip(np.asarray(verbalized_conf, dtype=float) / verbalized_scale, 0.0, 1.0)
+    if iconf.shape != vconf.shape:
+        raise ValueError(f"signal length mismatch: {iconf.shape} vs {vconf.shape}")
+    gap = iconf - vconf
+    internal_high = np.where(gap > margin)[0]
+    internal_low = np.where(gap < -margin)[0]
+    return {
+        "internal_high_verbal_low": internal_high,
+        "internal_low_verbal_high": internal_low,
+        "either": np.union1d(internal_high, internal_low),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Probe A capture & Probe C steering — nnsight-backed, run on the GPU host.
+# Interfaces are fixed here so the analysis above is written/tested against them now;
+# implementations land in the desktop/WSL2 session (DESIGN §7). See ../RUNBOOK once added.
+# ---------------------------------------------------------------------------
+
+_GPU_STUB = (
+    "{name} needs nnsight + open weights + a GPU and runs in the desktop/WSL2 session "
+    "(DESIGN §7). This cloud-session scaffold fixes the interface and tests the "
+    "GPU-independent analysis; wire the implementation when the 4090 is reachable."
+)
+
+
+def capture_activations(
+    model,
+    items: Sequence[dict],
+    layers: Sequence[int],
+    *,
+    locus: str = "answer_token",
+):
+    """Capture residual-stream activations at ``locus`` for each item, swept over ``layers``.
+
+    Target signature (implemented on the GPU host):
+        -> dict[int, np.ndarray]   # {layer: [n_items, d_model]}
+
+    ``locus`` is the pre-registered token to read (DESIGN §8: answer-commitment token by
+    default; optionally also the confidence-number token to separate reading vs writing the
+    report). Offload to CPU/disk — a single locus token is not a storage bottleneck.
+    """
+    raise NotImplementedError(_GPU_STUB.format(name="capture_activations"))
+
+
+def steer_and_reelicit(
+    model,
+    items: Sequence[dict],
+    direction: np.ndarray,
+    alphas: Sequence[float],
+    layer: int,
+):
+    """Add ``alpha * direction`` at ``layer``, re-elicit confidence, sweep ``alphas`` (Probe C).
+
+    Target signature (implemented on the GPU host):
+        -> dict[float, dict]   # {alpha: {"verbalized_conf": ndarray, "answer_changed": ndarray}}
+
+    Grounded iff stated confidence moves monotonically with alpha; confabulated iff the
+    report is unmoved while the decodable signal is clearly shifted. Always run with the
+    norm-matched random-direction control and a capability sanity check (DESIGN §8).
+    """
+    raise NotImplementedError(_GPU_STUB.format(name="steer_and_reelicit"))

--- a/experiments/introspection-probe/tests/test_probe.py
+++ b/experiments/introspection-probe/tests/test_probe.py
@@ -1,0 +1,129 @@
+"""Tests for the GPU-independent probe core.
+
+No nnsight, no GPU, no API: synthetic activations with a known relationship to correctness
+exercise the decode (Probe A), the steering-direction construction (Probe C), and the
+dissociation selector (Probe B). Verifies the calibration-eval metric bridge wires up.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from src.probe import (
+    ProbeResult,
+    confidence_direction,
+    dissociation_set,
+    fit_confidence_probe,
+    layer_sweep,
+)
+from src._calmetrics import auroc, m_ratio
+
+
+def _synthetic(n=400, d=32, signal=2.0, seed=0):
+    """Activations where one direction carries correctness, the rest is noise."""
+    rng = np.random.default_rng(seed)
+    correct = rng.integers(0, 2, size=n).astype(float)
+    direction = rng.standard_normal(d)
+    direction /= np.linalg.norm(direction)
+    acts = rng.standard_normal((n, d))
+    acts += signal * (correct[:, None] - 0.5) * direction[None, :]
+    return acts, correct, direction
+
+
+# --- Probe A: decode --------------------------------------------------------
+
+
+def test_probe_decodes_planted_signal():
+    acts, correct, _ = _synthetic(signal=2.5)
+    res = fit_confidence_probe(acts, correct, seed=1)
+    assert isinstance(res, ProbeResult)
+    # a strong planted signal should be decodable well above chance, out-of-fold
+    assert res.auroc > 0.8
+    assert res.internal_conf.shape == correct.shape
+    assert not np.isnan(res.internal_conf).any()  # every item scored out-of-fold
+    assert (res.internal_conf >= 0).all() and (res.internal_conf <= 1).all()
+
+
+def test_probe_on_pure_noise_is_chance():
+    rng = np.random.default_rng(7)
+    acts = rng.standard_normal((300, 16))
+    correct = rng.integers(0, 2, size=300).astype(float)  # independent of acts
+    res = fit_confidence_probe(acts, correct, seed=2)
+    # out-of-fold AUROC on label-independent features should sit near 0.5
+    assert 0.4 < res.auroc < 0.6
+
+
+def test_probe_oof_auroc_matches_calmetrics():
+    acts, correct, _ = _synthetic(signal=1.5)
+    res = fit_confidence_probe(acts, correct, seed=3)
+    # the ProbeResult.auroc must be exactly the bridged metric on the OOF predictions
+    assert res.auroc == pytest.approx(auroc(res.internal_conf, correct, scale=1.0))
+    assert res.m_ratio == pytest.approx(m_ratio(res.internal_conf, correct, scale=1.0), nan_ok=True)
+
+
+def test_probe_is_deterministic():
+    acts, correct, _ = _synthetic(signal=2.0)
+    a = fit_confidence_probe(acts, correct, seed=5)
+    b = fit_confidence_probe(acts, correct, seed=5)
+    assert a.auroc == b.auroc
+    np.testing.assert_array_equal(a.internal_conf, b.internal_conf)
+
+
+def test_fit_validates_shapes():
+    with pytest.raises(ValueError):
+        fit_confidence_probe(np.zeros((10,)), np.zeros(10))  # 1-D activations
+    with pytest.raises(ValueError):
+        fit_confidence_probe(np.zeros((10, 4)), np.zeros(9))  # length mismatch
+    with pytest.raises(ValueError):
+        fit_confidence_probe(np.zeros((10, 4)), np.zeros(10), n_folds=1)  # too few folds
+
+
+# --- layer sweep ------------------------------------------------------------
+
+
+def test_layer_sweep_returns_result_per_layer():
+    acts_hi, correct, _ = _synthetic(signal=3.0, seed=10)
+    acts_lo, _, _ = _synthetic(signal=0.0, seed=10)  # same labels, no signal
+    sweep = layer_sweep({5: acts_lo, 12: acts_hi}, correct, seed=4)
+    assert set(sweep) == {5, 12}
+    # the layer carrying the planted signal should decode better
+    assert sweep[12].auroc > sweep[5].auroc
+
+
+# --- Probe C: steering direction -------------------------------------------
+
+
+def test_confidence_direction_recovers_planted_axis():
+    acts, correct, planted = _synthetic(signal=3.0, seed=20)
+    direction = confidence_direction(acts, correct)
+    assert direction.shape == planted.shape
+    # diff-of-means should align with the planted correctness axis (cosine near +/-1)
+    cos = float(direction @ planted / (np.linalg.norm(direction) * np.linalg.norm(planted)))
+    assert abs(cos) > 0.7
+
+
+def test_confidence_direction_needs_both_classes():
+    acts = np.random.default_rng(0).standard_normal((20, 8))
+    with pytest.raises(ValueError):
+        confidence_direction(acts, np.ones(20))  # all "high", no contrast
+
+
+# --- Probe B: dissociation set ---------------------------------------------
+
+
+def test_dissociation_splits_by_direction():
+    # item 0: internal high (0.9), verbal low (10/100) -> internal_high_verbal_low
+    # item 1: internal low (0.1), verbal high (90/100) -> internal_low_verbal_high
+    # item 2: agree (0.8 vs 80) -> neither
+    internal = [0.9, 0.1, 0.8]
+    verbal = [10, 90, 80]
+    out = dissociation_set(internal, verbal, margin=0.3)
+    assert out["internal_high_verbal_low"].tolist() == [0]
+    assert out["internal_low_verbal_high"].tolist() == [1]
+    assert out["either"].tolist() == [0, 1]
+
+
+def test_dissociation_validates_shapes():
+    with pytest.raises(ValueError):
+        dissociation_set([0.5, 0.5], [50])


### PR DESCRIPTION
## What

Two parallel workstreams following the metacognition `ROADMAP.md` now that Step 1 is merged (#21/#22):

- **Step 2 (introspection-probe) — scaffolded ready-to-run.** The GPU-independent core of the grounding-chain analysis, so the flagship runs the moment the RTX 4090 is wired (the only real gate). The 4090 is set up on the maintainer's side; Tailscale wiring from a cloud session is the remaining one-time step.
- **Step 3 (agentic-metacognition) — design spike** answering the question raised this session: *can Jetty own much of this work?*

GPU work can't run from this cloud session (Tailscale isn't wired with an auth key here), so this PR is everything that's GPU-independent: implemented + tested analysis code, locked pre-registration, and the Step-3 design note.

## Step 2 — `experiments/introspection-probe/`

The flagship asks: is "CONFIDENCE: 80" **read from** an internal uncertainty representation, or confabulated after the answer? This PR implements the parts of `DESIGN.md` §3-4 that need only captured activation arrays:

- **`src/probe.py`**
  - `fit_confidence_probe` — linear probe decoding own-correctness (Probe A), **out-of-fold predictions** so the decoding AUROC is honest (no train-on-test, DESIGN §8). numpy-only, deterministic.
  - `layer_sweep` — per-layer fit for locus selection.
  - `confidence_direction` — diff-of-means steering vector in raw activation space (Probe C, norm-matchable).
  - `dissociation_set` — items where internal vs verbalized disagree (the confabulation-candidate / Probe-C focus set).
  - `capture_activations` / `steer_and_reelicit` — **nnsight-backed interface stubs**; signatures fixed so the analysis is written/tested against them now, implementations land on the GPU host.
- **`src/_calmetrics.py`** — importlib bridge to `calibration-eval/src/metrics.py` (type-2 AUROC, meta-d′, M-ratio). Single source of truth; no copy to drift. Avoids the `src`-package name collision between the two experiments.
- **`PREREGISTRATION.md`** — locks H1-H4, the answer-commitment-token locus rule, and controls (difficulty partialling, OOF, norm-matched random-direction steering control) **before** any capture. H3 is designed so the null is informative (decoupling = confabulation is itself the finding).
- **CI** (`.github/workflows/introspection-probe.yml`) — 10 CPU-only tests; the `[interp]` extra (nnsight/torch) stays off CI.

## Step 3 — `experiments/agentic-metacognition/DESIGN.md` (Jetty spike)

The honest verdict on Jetty, grounded against the real jetty.io API (`simple_judge`, `list_emit_await`, `extract_from_trajectories`, JSON runbooks; verified via docs.jetty.io):

- **Not Steps 1-2.** Scoring there is deterministic with ground truth (a judge would inject noise where the answer is known); Jetty's refine-until-passes loop is the exact confound the ROADMAP excludes; and it can't touch activations for Step 2. Inspect already handles the matrix parallelism.
- **Yes Step 3**, where the self-monitoring loop is the *object of study*, not a confound — exactly where the ROADMAP placed it. Architecture: imported competence signal (Step 1 verbalized / Step 2 internal) → thin deterministic policy (abstain/escalate/ask/route) → Jetty harness-only. Headline metric: risk-coverage / asymmetric-payoff vs answer-everything, scored judge-free off Step-1 labels.
- Flags an **adjacent judge-self-knowledge study** Jetty unlocks (type-2 metrics on `simple_judge` confidence vs human labels) that needs no Step-2 dependency, and reuses the Jetty wiring Auraken already needs (`sylveste-lfdy.1`).

## Verification

- `pytest` → **10 pass** (probe decode on planted signal; chance AUROC on pure noise; OOF AUROC matches the bridged metric; determinism; layer sweep; steering-direction recovery; dissociation split; shape validation).
- Step 3 doc is design-only; nothing executable.

## Bead candidates (cloud session — beads read-only; for the workstation to file)

- Wire Tailscale from a cloud session to the 4090 (`introspection-probe/scripts/join-tailnet.sh`) + confirm the exact small Hermes checkpoint on the NousResearch HF org, then run Probe A→B (H1/H2 decode + headroom).
- Implement `capture_activations` / `steer_and_reelicit` (nnsight) on the GPU host.
- Step-3 spike: one Jetty `risk_coverage` runbook on the Step-1 verbalized signal as a baseline (no Step-2 dependency).
- Judge-self-knowledge study (Step-3 §5).
- Confirm Jetty custom-step extensibility (`policy_gate`, `risk_coverage_curve`).

https://claude.ai/code/session_01QMXzC74Mo5WZiJUjXJzrLs

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMXzC74Mo5WZiJUjXJzrLs)_