### PR TITLE
feat(scripts): skill-listing byte-budget gate

### DIFF
--- a/scripts/check-skill-listing-budget.sh
+++ b/scripts/check-skill-listing-budget.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# check-skill-listing-budget — guard the eager skill-listing prefix size.
+#
+# Every plugin SKILL.md's frontmatter `description:` is loaded into the model's
+# context prefix on every session. With no budget, that listing creeps as
+# plugins are added (a prior compaction cut it to ~34.9KB; it had crept back to
+# ~38.5KB with no guard). This gate sums the deduplicated description bytes and
+# fails when they exceed a budget, so new skills must stay within budget or
+# justify raising it.
+#
+# Usage:
+#   scripts/check-skill-listing-budget.sh [--json] [--verbose]
+#
+# Environment overrides (for tests / non-standard checkouts):
+#   SKILL_LISTING_BUDGET_BYTES   max allowed total (default 33000)
+#   SKILL_PLUGINS_ROOT           plugins dir (default ~/.claude/plugins)
+#   SYLVESTE_ROOT                repo root (default: parent of this script's dir)
+#
+# Exit codes:
+#   0 — within budget
+#   1 — over budget
+#   2 — usage or measurement error
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${SYLVESTE_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+AUDIT="$SCRIPT_DIR/perf/audit-skill-contributions.py"
+
+BUDGET="${SKILL_LISTING_BUDGET_BYTES:-33000}"
+PLUGINS_ROOT="${SKILL_PLUGINS_ROOT:-$HOME/.claude/plugins}"
+JSON_OUT=false
+VERBOSE=false
+
+for arg in "$@"; do
+    case "$arg" in
+        --json) JSON_OUT=true ;;
+        --verbose | -v) VERBOSE=true ;;
+        --help | -h)
+            sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ ! -f "$AUDIT" ]]; then
+    echo "skill-budget: audit script not found at $AUDIT" >&2
+    exit 2
+fi
+if [[ ! -d "$PLUGINS_ROOT" ]]; then
+    echo "skill-budget: plugins root not found at $PLUGINS_ROOT (set SKILL_PLUGINS_ROOT)" >&2
+    exit 2
+fi
+
+# The audit cross-references an interstat metrics DB for MCP usage, which need
+# not exist in CI. desc_bytes comes purely from SKILL.md frontmatter, so point
+# --db at a path that won't exist and let the audit's usage lookup come back
+# empty — the byte totals are unaffected.
+audit_json=$(python3 "$AUDIT" \
+    --plugins-root "$PLUGINS_ROOT" \
+    --db "/nonexistent-skill-budget-db" \
+    --out - 2>/dev/null) || {
+    echo "skill-budget: audit failed" >&2
+    exit 2
+}
+
+total=$(printf '%s' "$audit_json" | python3 -c "
+import sys, json
+rows = json.load(sys.stdin)
+print(sum(int(r.get('desc_bytes', 0)) for r in rows))
+" 2>/dev/null) || {
+    echo "skill-budget: could not sum desc_bytes" >&2
+    exit 2
+}
+
+case "$total" in '' | *[!0-9]*)
+    echo "skill-budget: non-numeric total '$total'" >&2
+    exit 2
+    ;;
+esac
+
+over=$((total - BUDGET))
+tokens=$((total / 4))
+
+if $JSON_OUT; then
+    status=$([[ "$total" -le "$BUDGET" ]] && echo "ok" || echo "over")
+    printf '{"total_bytes":%d,"budget_bytes":%d,"over_by":%d,"approx_tokens":%d,"status":"%s"}\n' \
+        "$total" "$BUDGET" "$over" "$tokens" "$status"
+fi
+
+if [[ "$total" -le "$BUDGET" ]]; then
+    if $VERBOSE && ! $JSON_OUT; then
+        echo "skill-listing budget OK: ${total}B / ${BUDGET}B (~${tokens} tok), ${over#-}B headroom"
+    fi
+    exit 0
+fi
+
+if ! $JSON_OUT; then
+    echo "skill-listing OVER BUDGET: ${total}B > ${BUDGET}B (~${tokens} tok, +${over}B)" >&2
+    echo "  The eager skill listing loads into every session prefix. Either trim" >&2
+    echo "  the biggest descriptions (scripts/perf/audit-skill-contributions.py" >&2
+    echo "  --plugins-root \"$PLUGINS_ROOT\" lists them) or, if the growth is" >&2
+    echo "  justified, raise SKILL_LISTING_BUDGET_BYTES in CI deliberately." >&2
+fi
+exit 1

--- a/scripts/tests/skill_listing_budget.bats
+++ b/scripts/tests/skill_listing_budget.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# Tests for check-skill-listing-budget.sh — the eager skill-listing byte gate.
+
+SCRIPT="$BATS_TEST_DIRNAME/../check-skill-listing-budget.sh"
+
+# Build a hermetic fixture plugins root with two SKILL.md files whose
+# frontmatter descriptions have known byte sizes, so the gate's totals are
+# deterministic and independent of the real ~/.claude/plugins.
+setup() {
+    FIXTURE="$BATS_TEST_TMPDIR/plugins"
+    mkdir -p "$FIXTURE/alpha/skills/one" "$FIXTURE/beta/skills/two"
+    # description: "AAAA...10" → 10 bytes of value
+    cat >"$FIXTURE/alpha/skills/one/SKILL.md" <<'EOF'
+---
+name: one
+description: AAAAAAAAAA
+---
+body
+EOF
+    # description: 20 bytes
+    cat >"$FIXTURE/beta/skills/two/SKILL.md" <<'EOF'
+---
+name: two
+description: BBBBBBBBBBBBBBBBBBBB
+---
+body
+EOF
+    export SKILL_PLUGINS_ROOT="$FIXTURE"
+}
+
+@test "within budget: total under budget exits 0" {
+    SKILL_LISTING_BUDGET_BYTES=1000 run "$SCRIPT" --json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"status":"ok"'* ]]
+}
+
+@test "over budget: total over budget exits 1" {
+    SKILL_LISTING_BUDGET_BYTES=5 run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"OVER BUDGET"* ]]
+}
+
+@test "json output reports total, budget, and status" {
+    SKILL_LISTING_BUDGET_BYTES=1000 run "$SCRIPT" --json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"total_bytes":'* ]]
+    [[ "$output" == *'"budget_bytes":1000'* ]]
+    [[ "$output" == *'"approx_tokens":'* ]]
+}
+
+@test "total reflects summed description bytes from fixtures" {
+    # alpha=10 + beta=20 = 30 bytes
+    SKILL_LISTING_BUDGET_BYTES=1000 run "$SCRIPT" --json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"total_bytes":30'* ]]
+}
+
+@test "boundary: total exactly at budget passes (<=)" {
+    SKILL_LISTING_BUDGET_BYTES=30 run "$SCRIPT"
+    [ "$status" -eq 0 ]
+}
+
+@test "boundary: one byte under total fails" {
+    SKILL_LISTING_BUDGET_BYTES=29 run "$SCRIPT"
+    [ "$status" -eq 1 ]
+}
+
+@test "missing plugins root exits 2" {
+    SKILL_PLUGINS_ROOT="/nonexistent-skill-budget-root" run "$SCRIPT"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"plugins root not found"* ]]
+}
+
+@test "unknown argument exits 2" {
+    run "$SCRIPT" --bogus
+    [ "$status" -eq 2 ]
+}
+
+@test "help flag exits 0 and prints usage" {
+    run "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"check-skill-listing-budget"* ]]
+}


### PR DESCRIPTION
The eager skill listing (every plugin SKILL.md `description:`, loaded into the model prefix every session) had crept with no budget guard.

Adds `scripts/check-skill-listing-budget.sh` — sums deduplicated per-plugin description bytes and fails over `SKILL_LISTING_BUDGET_BYTES` (default 33000, ~1.3KB above the current 31660 so it ratchets). Exit 0/1/2, boundary-inclusive, works without an interstat DB. Hermetic bats tests (9/9).

**Note:** the deduplicated total is **31.6KB — already below the prior 34.9KB target**, so no re-compaction is needed now; the durable win is the gate preventing future creep. (The 38.5KB in the bead was a raw-glob over-count incl. cache dupes.)

A CI workflow is staged separately (`/Users/sma/.claude/jobs/.../pending-workflow/`) — the push token lacks `workflow` scope, so it needs to be added with a workflow-scoped token.

Independently verified (**VERDICT PASS**): exit codes correct, tests hermetic+deterministic, measurement faithful, no `set -e` footgun.

Closes sylveste-a4oj.10.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)