### PR TITLE
docs(beads): record what the post-merge import actually runs, and its cost

### DIFF
--- a/ops/beads-two-machine-sync.md
+++ b/ops/beads-two-machine-sync.md
@@ -17,8 +17,17 @@ Dolt database; the JSONL is how they reach each other.
 | Direction | Mechanism | Trigger |
 |---|---|---|
 | Dolt → JSONL | export, then a dedicated commit | `post-commit` |
-| JSONL → Dolt | `bd import` | `post-merge` |
+| JSONL → Dolt | `bd import`, via `scripts/beads-import-merged.sh` | `post-merge` |
 | deletions | `scripts/beads_apply_deletions.py`, after the import | `post-merge` |
+
+`beads-import-merged.sh` hands bd only the rows the merge changed. A full
+`bd import` of the file measures **~49s on Clavain and over 9 minutes on zklw**,
+and it would run on every pull — the retired importer had been avoiding that
+incidentally, by filtering before importing. git already knows which lines
+changed and every issue is one line, so the filter costs nothing and bd still
+applies its guard per row. Measured 49s → 1s. When the diff cannot be
+determined it imports the whole file: slow beats an import that silently skips
+another machine's work.
 
 Both machines set `core.hooksPath = <repo>/.beads/hooks`, so `.git/hooks/` is
 **never executed**. Anything installed there is inert. Confirmed on both.


### PR DESCRIPTION
The protocol table said `bd import`. What runs is `beads-import-merged.sh`, which hands bd only the rows the merge changed.

Adds the measurement that motivated it — including the number that made it urgent: the same full import that takes ~49s on Clavain ran for **over 9 minutes** on zklw, blocking the pull the whole time. The retired importer had been avoiding that incidentally by filtering before importing; the regression arrived with its removal.

Follow-up to #39 and #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)