### PR TITLE
beads: refuse to confirm a deletion when the local database is behind

### DIFF
--- a/ops/beads-two-machine-sync.md
+++ b/ops/beads-two-machine-sync.md
@@ -298,6 +298,17 @@ the import on `post-merge` and deletes exactly the ids named, refusing any whose
 local row is newer than the deletion record (someone worked it after the other
 machine dropped it) and saying so on stderr.
 
+`beads-confirm-deletion.sh` refuses if this database is missing beads the shared
+file has. It exports, and an export writes the local database over the file, so
+anything the file holds and Dolt lacks is destroyed by it — the same reason
+`beads-auto-export.sh` refuses in that state. The first version called
+`bd export` directly and skipped the check. A probe caught it: zklw's import had
+been killed mid-flight, its database was five beads behind, and confirming one
+deletion produced an export with **six** beads missing — including the bead
+tracking this work. It was on an unmerged branch, so nothing was lost, but that
+was luck. Covered by scenario 8 of `tests/test_beads_deletion_propagation.sh`,
+which fails when the guard is removed.
+
 Measured before and after, on two real Dolt databases with a bare remote between
 them, in both directions:
 

--- a/scripts/beads-confirm-deletion.sh
+++ b/scripts/beads-confirm-deletion.sh
@@ -45,6 +45,40 @@ command -v bd >/dev/null 2>&1 || { echo "bd not on PATH" >&2; exit 1; }
 
 cd "$ROOT"
 
+# Refuse if the local database is behind the shared file.
+#
+# This script exports, and an export writes the local database over the file —
+# so any bead the file has and this database lacks is destroyed by it. That is
+# the whole reason beads-auto-export.sh refuses in this state, and the first
+# version of this script bypassed that guard by calling `bd export` directly.
+#
+# Caught by a probe: zklw's import had been killed mid-flight, so its database
+# was missing five beads that were on main. Confirming ONE deletion there
+# exported a file with six beads gone, including the bead tracking this very
+# work. It was on an unmerged branch, so nothing was lost — but that is luck,
+# not design.
+#
+# The beads being confirmed are expected to be missing locally. Anything else
+# missing is another machine's work, and this stops rather than guessing.
+if [ -f "$ROOT/scripts/check_beads_jsonl_dolt_sync.py" ]; then
+  unexpected="$(python3 "$ROOT/scripts/check_beads_jsonl_dolt_sync.py" --json 2>/dev/null \
+    | python3 -c '
+import json, sys
+try:
+    missing = set(json.load(sys.stdin).get("missing_in_dolt") or [])
+except Exception:
+    raise SystemExit(0)          # no verdict; the export path guards separately
+print(" ".join(sorted(missing - set(sys.argv[1:]))))
+' "${IDS[@]}")"
+  if [ -n "$unexpected" ]; then
+    echo "refusing: this database is missing beads that .beads/issues.jsonl has," >&2
+    echo "          and exporting now would delete them along with your deletion:" >&2
+    for missing_id in $unexpected; do echo "            $missing_id" >&2; done
+    echo "          Import them first:  bd import .beads/issues.jsonl" >&2
+    exit 1
+  fi
+fi
+
 for id in "${IDS[@]}"; do
   if bd show "$id" >/dev/null 2>&1; then
     if [ "$DELETE_LOCAL" -eq 1 ]; then

--- a/tests/test_beads_deletion_propagation.sh
+++ b/tests/test_beads_deletion_propagation.sh
@@ -137,4 +137,37 @@ if bash scripts/beads-confirm-deletion.sh keep-1 >/dev/null 2>&1; then
 fi
 present keep-1 || fail "the refusal deleted the bead anyway"
 
+# ─── 8: refuses to export over another machine's unimported work ──────
+# The regression: this script exports, and an export writes the local database
+# over the shared file, so any bead the file has and this database lacks is
+# destroyed by it. The first version called `bd export` directly and skipped
+# the guard that beads-auto-export.sh applies for exactly this reason. On zklw,
+# whose import had been killed mid-flight, confirming ONE deletion produced an
+# export with SIX beads missing.
+echo "=== 8: refusing to export when the local database is behind the file ==="
+reset_db
+rm -f .beads/deletions.jsonl
+# The checker the script consults, stubbed to compare the file against the db.
+cat > scripts/check_beads_jsonl_dolt_sync.py <<'CHECK'
+import json, os, sys
+db = os.environ["BD_STUB_DB"]
+local = {l.split("\t")[0] for l in open(db) if l.strip()}
+in_file = set()
+for line in open(".beads/issues.jsonl"):
+    line = line.strip()
+    if line:
+        in_file.add(json.loads(line)["id"])
+print(json.dumps({"missing_in_dolt": sorted(in_file - local)}))
+CHECK
+# The file carries a bead this database has never seen — another machine's work.
+{ printf '{"id":"keep-1"}\n{"id":"target"}\n{"id":"from-elsewhere"}\n'; } > .beads/issues.jsonl
+
+if bash scripts/beads-confirm-deletion.sh --delete-local target >/dev/null 2>&1; then
+  fail "exported over a bead this database had never imported"
+fi
+[ -f .beads/deletions.jsonl ] && fail "recorded a deletion it then refused to carry out"
+grep -q 'from-elsewhere' .beads/issues.jsonl || fail "the other machine's bead was dropped from the file"
+present target || fail "deleted locally before checking whether the export was safe"
+rm -f scripts/check_beads_jsonl_dolt_sync.py
+
 echo "all deletion-propagation scenarios passed"


### PR DESCRIPTION
Fixes a bug in #39, found by the live probe rather than by reasoning.

`beads-confirm-deletion.sh` exports, and an export writes the local database over the shared file — so **any bead the file has and this database lacks is destroyed by it**. That is exactly why `beads-auto-export.sh` refuses in that state. This script called `bd export` directly and skipped the check.

zklw's import had been killed mid-flight, so its database was five beads behind main. Confirming **one** probe deletion there produced an export with **six** beads missing — including `Sylveste-n6xc`, the bead tracking this work, and `Sylveste-sb6z`, filed an hour earlier. The commit was on an unmerged branch so nothing was lost, but that is luck rather than design, and the guard that would have caught it already existed one script over.

The beads being confirmed are expected to be missing locally; anything else missing is another machine's work, and the script now stops and names it:

```
refusing: this database is missing beads that .beads/issues.jsonl has,
          and exporting now would delete them along with your deletion:
            Sylveste-n6xc
            Sylveste-sb6z
          Import them first:  bd import .beads/issues.jsonl
```

Checked **before** any local delete, so a refusal leaves nothing half-done.

Scenario 8 of `tests/test_beads_deletion_propagation.sh` covers it, and was verified to fail when the guard is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)