### PR TITLE
beads: actually remove .beads/metadata.json from the index

### DIFF
--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,8 +1,0 @@
-{
-  "database": "dolt",
-  "backend": "dolt",
-  "dolt_mode": "server",
-  "dolt_server_port": 57745,
-  "dolt_database": "Sylveste",
-  "project_id": "07e89680-8485-4489-a63a-9105595860b2"
-}

--- a/tests/test_beads_metadata_isolation.sh
+++ b/tests/test_beads_metadata_isolation.sh
@@ -79,6 +79,20 @@ build_pair() {   # build_pair <root> <track-metadata: yes|no>
   return 0
 }
 
+echo "=== 0: THIS repository does not track its own pointer ==="
+# The scenarios below all run in a sandbox, and a sandbox cannot notice that the
+# change never landed here. It did not, once: `git rm --cached` staged the
+# removal and a pathspec commit naming the same file re-added it from the
+# working tree, so the ignore rule shipped against a still-tracked path and did
+# nothing. Both the commit and CI were satisfied.
+if git -C "$ROOT" ls-files --error-unmatch .beads/metadata.json >/dev/null 2>&1; then
+  fail ".beads/metadata.json is tracked in this repository; the ignore rule at
+      .beads/.gitignore has no effect on a path git is already tracking.
+      Fix with:  git rm --cached .beads/metadata.json  (then commit the INDEX,
+      not a pathspec naming that file)"
+fi
+[ -f "$ROOT/.beads/metadata.json" ] || echo "    (note: no local metadata.json — bd bootstrap has not run here)"
+
 echo "=== 1: with metadata.json tracked, B's bd init retargets A ==="
 R1="$SANDBOX/tracked"; mkdir -p "$R1"
 if ! build_pair "$R1" yes; then echo "    (skipped: bd init failed in the sandbox)"; exit 0; fi


### PR DESCRIPTION
#49 added the ignore rule and the test but **left the file tracked**, so nothing changed — an ignore rule has no effect on a path git already tracks. `git ls-tree HEAD .beads/metadata.json` still returned it on both machines.

## What went wrong

`git rm --cached` staged the deletion, and then `git commit -F msg -- <paths>` with `metadata.json` among the paths undid it. The pathspec form commits the **working tree** state of the named paths and deliberately ignores the index — which is exactly why it's the safe form for atomic commits, and exactly why it re-added a file whose only pending change lived in the index.

The commit succeeded and CI passed because nothing was wrong. Nothing had been removed.

## This PR

- stages the removal and commits the **index**, with nothing else staged
- verified by `git ls-tree` rather than by the commit's own output, which was happy about the wrong thing last time
- adds **scenario 0** to the isolation test: assert that *this* repository does not track its own pointer. Every other scenario runs in a sandbox, and a sandbox cannot notice that the change never landed in the repository shipping it. Verified to fail on a tracked `metadata.json`.

Sylveste-sb6z

🤖 Generated with [Claude Code](https://claude.com/claude-code)