### PR TITLE
publish-drift: stop abstaining on plugins that are not checked out here

### DIFF
--- a/scripts/check-publish-drift.py
+++ b/scripts/check-publish-drift.py
@@ -30,12 +30,33 @@ but does NOT commit the plugin repo, so the version bump can sit uncommitted in 
 working tree while the marketplace already advertises it. Then no bump commit
 exists at all, and a naive check silently finds nothing to compare.
 
+Where the source comes from
+---------------------------
+A verdict of "undetermined" is the failure mode that quietly kills a check like
+this: three plugins reported "no local repo" on Clavain simply because they were
+never cloned there, and an audit that abstains on 3 of 67 trains you to read a
+green result as "mostly green". So the source is resolved in two tiers:
+
+  1. A LOCAL checkout, when one exists. Preferred, and not merely for speed — only
+     a working tree can show a bump that was published but never committed, or
+     commits that exist locally and have not been pushed. Those are real drift and
+     a remote can never see them.
+  2. Otherwise the repo named by the marketplace entry's own `source.url`, fetched
+     into a bare mirror cache. Every entry carries one, so no plugin needs to be
+     checked out on a machine for that machine to judge it.
+
+This also means the two machines no longer need their verdicts reconciled: either
+can determine all 67 on its own. Where they legitimately disagree, the machine
+holding unpushed commits is the one telling the truth, and its verdict is the
+stricter one.
+
 Exit codes: 0 clean, 1 drift found, 2 could not determine (use --strict to fail on 2).
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -49,6 +70,11 @@ SHIPPED_SURFACE = ("hooks", "skills", "commands", "agents", "lib", "scripts", "m
 DEFAULT_MARKETPLACE = (
     Path.home() / ".claude/plugins/marketplaces/interagency-marketplace/.claude-plugin/marketplace.json"
 )
+DEFAULT_CACHE = Path(os.environ.get("PUBLISH_DRIFT_CACHE", Path.home() / ".cache/publish-drift"))
+
+# A mirror fetch that hangs is worse than one that fails: this runs on a timer, and
+# a wedged git-over-https blocks every later check in the same run.
+NET_TIMEOUT = 120
 
 
 def git(repo: Path, *args: str, timeout: int = 30) -> str:
@@ -82,12 +108,77 @@ def discover_repos(roots: list[Path]) -> dict[str, Path]:
     return repos
 
 
-def published_versions(marketplace: Path) -> dict[str, str | None]:
+def marketplace_entries(marketplace: Path) -> dict[str, dict]:
     data = json.load(open(marketplace))
     plugins = data.get("plugins") or []
     if isinstance(plugins, dict):
         plugins = [dict(v, name=k) for k, v in plugins.items()]
-    return {p["name"]: p.get("version") for p in plugins if p.get("name")}
+    return {p["name"]: p for p in plugins if p.get("name")}
+
+
+def source_url(entry: dict) -> str:
+    """The git URL a marketplace entry points at, if it points at one.
+
+    `source` is either a bare string or an object; only the url/git forms name a
+    repository we can mirror. Anything else (a local path source, say) is not
+    fetchable and stays undetermined rather than being guessed at.
+    """
+    src = entry.get("source")
+    if isinstance(src, str):
+        return src if src.endswith(".git") or src.startswith("http") else ""
+    if isinstance(src, dict):
+        url = src.get("url") or src.get("repo") or ""
+        return url if isinstance(url, str) else ""
+    return ""
+
+
+def mirror(name: str, url: str, cache: Path, offline: bool) -> Path | None:
+    """Bare mirror of a plugin's published source, refreshed in place.
+
+    Bare on purpose: this only ever reads history, and a mirror of 67 repos with
+    working trees would cost disk for nothing. `git ls-tree` replaces every
+    filesystem existence check below so the same audit runs against either shape.
+    """
+    dest = cache / f"{name}.git"
+    if dest.is_dir():
+        if offline:
+            return dest
+        # Refresh; a failed fetch leaves the previous mirror intact and usable,
+        # so a network blip degrades the answer's freshness rather than losing it.
+        git(dest, "fetch", "--prune", "--quiet", "origin", "+refs/heads/*:refs/heads/*",
+            timeout=NET_TIMEOUT)
+        return dest
+    if offline:
+        return None
+    cache.mkdir(parents=True, exist_ok=True)
+    try:
+        # URL comes from the marketplace manifest: passed as its own argv entry,
+        # never interpolated into a shell string.
+        r = subprocess.run(
+            ["git", "clone", "--bare", "--quiet", url, str(dest)],
+            capture_output=True, text=True, timeout=NET_TIMEOUT,
+        )
+    except Exception:
+        return None
+    return dest if r.returncode == 0 and dest.is_dir() else None
+
+
+def resolve_tip(repo: Path) -> str:
+    for ref in ("origin/main", "origin/master", "refs/heads/main", "refs/heads/master"):
+        if git(repo, "rev-parse", "--verify", "-q", ref):
+            return ref
+    return "HEAD"
+
+
+def tree_entries(repo: Path, tip: str) -> set[str]:
+    """Top-level names present in the tree at `tip`.
+
+    Replaces `(repo / p).exists()`: a bare mirror has no working tree, and even in
+    a checkout the question is what the COMMIT contains, not what happens to be
+    lying in the directory.
+    """
+    out = git(repo, "ls-tree", "--name-only", tip)
+    return {line.strip().rstrip("/") for line in out.splitlines() if line.strip()}
 
 
 def manifest_version(repo: Path, ref: str | None = None) -> str | None:
@@ -115,10 +206,11 @@ def find_bump(repo: Path, tip: str, version: str) -> str:
     return ""
 
 
-def audit(repo: Path, published: str) -> dict:
-    tip = "origin/main" if git(repo, "rev-parse", "--verify", "-q", "origin/main") else "HEAD"
+def audit(repo: Path, published: str, bare: bool = False) -> dict:
+    tip = resolve_tip(repo)
 
-    if manifest_version(repo) == published and manifest_version(repo, tip) != published:
+    # Only a working tree can show a bump that was published but never committed.
+    if not bare and manifest_version(repo) == published and manifest_version(repo, tip) != published:
         return {
             "status": "uncommitted-bump",
             "detail": f"working tree {published}, {tip} {manifest_version(repo, tip)} — "
@@ -129,7 +221,8 @@ def audit(repo: Path, published: str) -> dict:
     if not bump:
         return {"status": "undetermined", "detail": f"no commit sets plugin.json to {published}"}
 
-    paths = [p for p in SHIPPED_SURFACE if (repo / p).exists()]
+    present = tree_entries(repo, tip)
+    paths = [p for p in SHIPPED_SURFACE if p in present]
     if not paths:
         return {"status": "clean", "detail": "no shipped surface"}
 
@@ -160,6 +253,12 @@ def main() -> int:
                     help="repo root to scan (repeatable)")
     ap.add_argument("--plugin", action="append", default=None, help="limit to these plugins")
     ap.add_argument("--strict", action="store_true", help="treat undetermined as failure")
+    ap.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE,
+                    help="bare-mirror cache for plugins with no local checkout")
+    ap.add_argument("--offline", action="store_true",
+                    help="never touch the network; use existing mirrors only")
+    ap.add_argument("--no-mirror", action="store_true",
+                    help="local checkouts only (restores pre-mirror behaviour)")
     ap.add_argument("--json", action="store_true")
     args = ap.parse_args()
 
@@ -169,16 +268,37 @@ def main() -> int:
         return 2
 
     repos = discover_repos(roots)
+    entries = marketplace_entries(args.marketplace)
     results = {}
-    for name, version in sorted(published_versions(args.marketplace).items()):
+    for name, entry in sorted(entries.items()):
         if args.plugin and name not in args.plugin:
             continue
+        version = entry.get("version")
         if not version:
             continue
+
         repo = repos.get(name)
-        results[name] = ({"status": "undetermined", "detail": "no local repo"}
-                         if not repo else audit(repo, version))
-        results[name]["published"] = version
+        if repo:
+            r = audit(repo, version)
+            r["source"] = "local"
+        elif args.no_mirror:
+            r = {"status": "undetermined", "detail": "no local repo", "source": "-"}
+        else:
+            url = source_url(entry)
+            if not url:
+                r = {"status": "undetermined",
+                     "detail": "no local repo and no fetchable source in the marketplace entry",
+                     "source": "-"}
+            else:
+                m = mirror(name, url, args.cache_dir, args.offline)
+                if not m:
+                    r = {"status": "undetermined",
+                         "detail": f"no local repo; could not mirror {url}", "source": "-"}
+                else:
+                    r = audit(m, version, bare=True)
+                    r["source"] = "mirror"
+        r["published"] = version
+        results[name] = r
 
     if args.json:
         print(json.dumps(results, indent=2, sort_keys=True))
@@ -187,9 +307,11 @@ def main() -> int:
         uncommitted = {k: v for k, v in results.items() if v["status"] == "uncommitted-bump"}
         undet = {k: v for k, v in results.items() if v["status"] == "undetermined"}
         clean = [k for k, v in results.items() if v["status"] == "clean"]
+        mirrored = sum(1 for v in results.values() if v.get("source") == "mirror")
 
         print(f"{len(results)} published plugins: {len(clean)} clean, {len(drift)} drifted, "
-              f"{len(uncommitted)} uncommitted bump, {len(undet)} undetermined\n")
+              f"{len(uncommitted)} uncommitted bump, {len(undet)} undetermined"
+              f"  ({mirrored} judged from a source mirror)\n")
         if drift:
             print(f"{'plugin':<16} {'published':<10} {'unshipped':>9} {'oldest':>7}  commits")
             print("-" * 100)


### PR DESCRIPTION
publish-drift: stop abstaining on plugins that are not checked out here

The checker reported "undetermined — no local repo" for interdeploy, interjawn
and intersense on Clavain, purely because those three were never cloned there.
Abstaining on 3 of 67 is how a check like this decays: a green summary that
quietly excludes an unexamined slice trains you to read it as a green estate.

Source resolution is now two-tier. A local checkout still wins, and not only for
speed — only a working tree can see a bump that was published but never
committed, or commits that exist locally and have not been pushed. Both are real
drift and no remote can show them. Failing that, the checker mirrors the repo
named by the entry's own source.url into a bare cache under
~/.cache/publish-drift and audits that. Every marketplace entry carries one, so
no plugin needs a checkout on a machine for that machine to judge it.

This also retires the idea of reconciling two machines' verdicts: either can now
determine all of them alone. Where they disagree, the machine holding unpushed
commits is the stricter and more truthful one.

Mechanically the audit had to stop touching the filesystem to work against a
bare mirror: `(repo / p).exists()` became `git ls-tree` at the tip, which is
also the more correct question — what the COMMIT contains, not what happens to
be lying in the directory. The uncommitted-bump branch is skipped for mirrors,
which have no working tree to disagree with.

Immediate result: 0 undetermined, and the fallback converted one of the three
abstentions into a finding. intersense showed 1 unshipped commit, 153 days old,
because it was archived in March and has been advertised as installable ever
since with no plugin manifest at all. Delisted separately in the marketplace
repo (15a8d28), which is why the estate is now 66 plugins rather than 67.

Also adds --offline (use existing mirrors, never touch the network) and
--no-mirror (restore the previous local-only behaviour).
