### PR TITLE
A manual workflow nobody has dispatched is not a broken one

### DIFF
--- a/scripts/check-workflow-health.py
+++ b/scripts/check-workflow-health.py
@@ -38,6 +38,44 @@ def gh_json(path):
         return None
 
 
+def gh_raw(path):
+    p = subprocess.run(
+        ["gh", "api", "-H", "Accept: application/vnd.github.raw", path],
+        capture_output=True, text=True)
+    return p.stdout if p.returncode == 0 else None
+
+
+def triggers(repo, path):
+    """The event names a workflow declares, or None if they cannot be read.
+
+    None rather than an empty set when the file cannot be fetched or parsed:
+    "declares no triggers" and "I could not read its triggers" are different
+    claims, and only the first would justify softening a verdict. Anything
+    unreadable keeps the stricter reading.
+    """
+    txt = gh_raw(f"repos/{OWNER}/{repo}/contents/{path}")
+    if txt is None:
+        return None
+    try:
+        import yaml
+    except ImportError:
+        return None
+    try:
+        doc = yaml.safe_load(txt)
+    except Exception:
+        return None
+    if not isinstance(doc, dict):
+        return None
+    # YAML 1.1 reads a bare `on:` key as the boolean True, so a workflow's most
+    # important line is the one most likely to be missed by a dict lookup.
+    node = doc.get("on", doc.get(True))
+    if isinstance(node, str):
+        return {node}
+    if isinstance(node, (list, dict)):
+        return set(node)
+    return None
+
+
 def estate_repos(root: Path):
     names = []
     clav = root / "os" / "Clavain"
@@ -69,7 +107,7 @@ def main(argv=None):
               f"checkout.", file=sys.stderr)
         return 2
 
-    disabled, never = [], []
+    disabled, never, manual = [], [], []
     inspected = 0
     for repo in repos:
         data = gh_json(f"repos/{OWNER}/{repo}/actions/workflows")
@@ -87,16 +125,32 @@ def main(argv=None):
                 continue
             runs = gh_json(f"repos/{OWNER}/{repo}/actions/workflows/{w['id']}/runs?per_page=1")
             if runs is not None and runs.get("total_count", 0) == 0:
-                never.append((repo, name))
+                # A workflow_dispatch-only workflow has no automatic trigger, so
+                # "never ran" means nobody has needed it yet -- not that anything
+                # is wrong. cxdb-release.yml is a manual cross-compile release
+                # build, and counting it as a fault made this check report a
+                # failure every day for a workflow behaving exactly as designed.
+                #
+                # Still reported, because unvalidated is a real thing to know
+                # about a release path. Just not a failure.
+                ev = triggers(repo, w.get("path", ""))
+                if ev is not None and ev <= {"workflow_dispatch"}:
+                    manual.append((repo, name))
+                else:
+                    never.append((repo, name))
 
     if not args.quiet:
         for repo, name, state in sorted(disabled):
             print(f"DISABLED  {repo:16} {name:30} state={state}")
         for repo, name in sorted(never):
             print(f"NEVER-RAN {repo:16} {name:30} (never validated)")
+        for repo, name in sorted(manual):
+            print(f"MANUAL    {repo:16} {name:30} "
+                  f"(workflow_dispatch only; never dispatched)")
 
+    tail = f", {len(manual)} manual-only never dispatched" if manual else ""
     print(f"{inspected} repo(s) inspected: {len(disabled)} disabled, "
-          f"{len(never)} never ran")
+          f"{len(never)} never ran{tail}")
     if disabled:
         print("  re-enable: gh api --method PUT "
               "repos/mistakeknot/<repo>/actions/workflows/<id>/enable")


### PR DESCRIPTION
A manual workflow nobody has dispatched is not a broken one

estate-workflow-health has failed every day on a single line:

    NEVER-RAN Sylveste  cxdb-release.yml  (never validated)

cxdb-release.yml is `on: workflow_dispatch:` and nothing else -- a manual
cross-compile release build for cxdb, taking a version tag and a ref as inputs.
It has never run because nobody has ever needed to cut that release, which is
precisely what a manual workflow does until someone dispatches it.

The check's own docstring explains why "never ran" was a fault: a workflow that
has never executed is indistinguishable from one that is broken. That reasoning
is sound for a workflow with an automatic trigger -- if push or schedule should
have fired it and never did, something is wrong. It does not carry to a workflow
whose only trigger is a human deciding to press the button.

So the trigger set decides. `on:` is read from the workflow file and a workflow
declaring nothing but workflow_dispatch is reported as MANUAL and not counted as
a failure. Everything else keeps the strict reading, including the case that
motivated this check: GitHub silently disabling secret-scan.yml on 17 of 36
plugin repos after 60 days of inactivity.

Two things kept deliberately conservative:

  triggers() returns None when the file cannot be fetched, yaml is unavailable,
  or the document does not parse. "Declares no triggers" and "I could not read
  its triggers" are different claims, and only the first should soften a
  verdict, so anything unreadable stays in the strict path.

  YAML 1.1 parses a bare `on:` key as the boolean True, so the lookup checks
  both. A workflow's most important line is the one most likely to be missed.

Still printed, not silenced -- an unvalidated release path is worth knowing
about. It is just not a failure, and a check that is permanently red is one
nobody reads.

  before:  67 repo(s) inspected: 0 disabled, 1 never ran            exit 1
  after:   67 repo(s) inspected: 0 disabled, 0 never ran,
                                 1 manual-only never dispatched     exit 0

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
