### PR TITLE
chore(security): supply-chain cooldown with an enforcement check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,12 @@
+# Supply-chain cooldown: dependency update PRs wait out the same 7-day window
+# that .npmrc's min-release-age enforces locally, so a compromised release has
+# a week to be caught before it reaches a branch. Security-advisory PRs are
+# exempt from cooldown by design, so CVE fixes still arrive promptly.
+#
+# This half is enforced by GitHub, not by the local toolchain — it applies
+# regardless of which npm wins on PATH. See
+# ops/scripts/check-supply-chain-cooldown.sh for the local half, which is
+# silently ignored by npm < 11.10.
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -5,6 +14,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 7
     labels:
       - "ci-drift"
     commit-message:

--- a/ops/scripts/check-supply-chain-cooldown.sh
+++ b/ops/scripts/check-supply-chain-cooldown.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Verify the npm supply-chain cooldown is ACTIVE, not merely configured.
+#
+# `min-release-age` is ignored silently by npm < 11.10. A repo can carry a
+# correct .npmrc, pass review, and enforce nothing — the config being present
+# is not evidence that it applies. This script separates the two questions and
+# fails when they disagree.
+#
+# Exit codes:
+#   0  configured AND enforceable
+#   1  configured but NOT enforceable (npm too old) — the dangerous case
+#   2  not configured
+#
+# Usage: check-supply-chain-cooldown.sh [dir ...]   (default: cwd)
+
+set -uo pipefail
+
+MIN_NPM_MAJOR=11
+MIN_NPM_MINOR=10
+
+npm_version="$(npm --version 2>/dev/null || echo "")"
+if [ -z "$npm_version" ]; then
+  echo "FAIL  npm not found on PATH — cannot assess enforcement."
+  exit 1
+fi
+
+npm_major="${npm_version%%.*}"
+npm_rest="${npm_version#*.}"
+npm_minor="${npm_rest%%.*}"
+
+enforceable=0
+if [ "$npm_major" -gt "$MIN_NPM_MAJOR" ] 2>/dev/null; then
+  enforceable=1
+elif [ "$npm_major" -eq "$MIN_NPM_MAJOR" ] 2>/dev/null && [ "$npm_minor" -ge "$MIN_NPM_MINOR" ] 2>/dev/null; then
+  enforceable=1
+fi
+
+if [ "$enforceable" -eq 1 ]; then
+  echo "npm $npm_version — min-release-age IS enforced (need >= ${MIN_NPM_MAJOR}.${MIN_NPM_MINOR})"
+else
+  echo "npm $npm_version — min-release-age is SILENTLY IGNORED (need >= ${MIN_NPM_MAJOR}.${MIN_NPM_MINOR})"
+  echo "      fix: npm install -g npm@latest"
+fi
+
+status=0
+configured_any=0
+
+for dir in "${@:-$PWD}"; do
+  value="$(cd "$dir" 2>/dev/null && npm config get min-release-age 2>/dev/null)"
+  if [ -z "$value" ] || [ "$value" = "undefined" ] || [ "$value" = "null" ]; then
+    echo "  NOT CONFIGURED  $dir"
+    [ "$status" -eq 0 ] && status=2
+  else
+    configured_any=1
+    if [ "$enforceable" -eq 1 ]; then
+      echo "  ACTIVE ${value}d      $dir"
+    else
+      echo "  INERT  ${value}d      $dir  <-- configured but not enforced"
+      status=1
+    fi
+  fi
+done
+
+# A cooldown that is configured everywhere but enforced nowhere is the exact
+# failure this script exists to name: it reads as protection in review while
+# providing none at install time.
+if [ "$configured_any" -eq 1 ] && [ "$enforceable" -eq 0 ]; then
+  echo
+  echo "VERDICT: cooldown is configured but INERT. Upgrade npm before trusting it."
+  exit 1
+fi
+
+exit "$status"


### PR DESCRIPTION
Adopts the 7-day dependency cooldown from [PrimeIntellect/prime-agent](https://github.com/PrimeIntellect-ai/prime-agent) — never resolve to a package version published less than a week ago, so a compromised release has time to be caught before it reaches a branch.

## Two halves, because they fail differently

| | Enforced by | Active now? |
|---|---|---|
| `dependabot.yml` → `cooldown.default-days: 7` | GitHub | **Yes** |
| `min-release-age=7` in user `~/.npmrc` | local npm | **No** — see below |

Security-advisory PRs are exempt from dependabot cooldown by design, so CVE fixes still arrive promptly.

`min-release-age` went in the **user** npmrc, not a repo file: npm does **not** walk up the directory tree for `.npmrc` (verified — a child dir with no local file resolves the key as `undefined`), so a monorepo-root file would have covered nothing.

## Why there's a checker

This setting fails silently. npm < 11.10 ignores `min-release-age` entirely, so a repo can carry correct config, pass review, and enforce nothing. `ops/scripts/check-supply-chain-cooldown.sh` separates *configured* from *enforceable* and exits non-zero when they disagree.

```
$ ops/scripts/check-supply-chain-cooldown.sh interverse/tool-time
npm 10.9.8 — min-release-age is SILENTLY IGNORED (need >= 11.10)
      fix: npm install -g npm@latest
  INERT  7d      interverse/tool-time  <-- configured but not enforced

VERDICT: cooldown is configured but INERT. Upgrade npm before trusting it.
```

## Open item for a human

The local half is **inert on Clavain**. Four npm binaries are installed; the winner is `~/.local/bin/npm`, a symlink into **Hermes's bundled node** (10.9.8). npm 12.0.2 is installed at `~/.npm-global/bin` but sits later on PATH. Repointing that symlink touches the Hermes runtime, so it's left as a decision rather than changed here.

## Enforcement verified empirically

Under npm 12.0.2 — observed behavior change, not config presence:

```
@aws-sdk/client-s3   off -> 3.1105.0 (published today)     on -> 3.1100.0
caniuse-lite         off -> 1.0.30001807 (published today) on -> 1.0.30001806
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP9aw3farEUYnyizz5zwmd