### PR TITLE
two estate checks whose pass could not be made to fail

### DIFF
--- a/scripts/check-kimi-version-parity.py
+++ b/scripts/check-kimi-version-parity.py
@@ -47,6 +47,26 @@ def read_version(path):
         return f"<unreadable: {exc}>"
 
 
+def usable(version) -> bool:
+    """Whether a value read by read_version can carry a parity verdict.
+
+    A NON-VERSION IS NOT A MATCHING VERSION. The comparison this file is built
+    on is `got != want`, and equality is the wrong test the moment both sides
+    can be absent: two manifests that each lack a `version` key both read None,
+    None equals None, and the pair is declared in parity on the strength of a
+    field neither of them has. Two manifests that are both unreadable are worse,
+    because they fail identically — two empty files produce the same
+    JSONDecodeError text, so their `<unreadable: ...>` markers match and the
+    check reports parity for a plugin whose manifests it could not even parse.
+
+    Measured 2026-08-07 on a synthetic estate: three plugins with empty
+    manifests, `parity ok: 3 plugin(s)`, exit 0. The equality held. It just was
+    not about anything.
+    """
+    return (isinstance(version, str) and bool(version)
+            and not version.startswith("<unreadable"))
+
+
 def plugin_roots(root, estate):
     """Yield plugin roots. A single repo yields itself; an estate walks it."""
     if estate:
@@ -120,6 +140,15 @@ def main(argv=None):
                               "kimi.plugin.json is missing"))
             continue
         got = read_version(generated)
+        if not usable(want) or not usable(got):
+            # Reported as drift rather than as unassessable on purpose. The
+            # `unassessable` bucket below is for facts about THIS MACHINE — a
+            # checkout too stale to judge from — and a manifest with no readable
+            # version is not that. It is a defect in the plugin repo, it travels
+            # with the repo, and pulling will not fix it.
+            drift.append((plugin.name, want, got,
+                          "no readable version to compare"))
+            continue
         if got != want:
             drift.append((plugin.name, want, got,
                           "version bumped without regenerating"))

--- a/scripts/check-workflow-health.py
+++ b/scripts/check-workflow-health.py
@@ -135,6 +135,11 @@ def estate_repos(root: Path):
     dropped, so it surfaces as unreachable instead of vanishing. Nothing here is
     allowed to leave the list silently — that is the whole lesson of this file.
     """
+    # Resolved, because Path(".").name is the empty string and `--root .` is a
+    # perfectly ordinary way to invoke this. Unresolved it printed a repo whose
+    # label was blank, which reads as a formatting glitch rather than as the
+    # missing name it actually is.
+    root = root.resolve()
     found = []
     clav = root / "os" / "Clavain"
     if (clav / ".git").is_dir():

--- a/scripts/check-workflow-health.py
+++ b/scripts/check-workflow-health.py
@@ -14,9 +14,12 @@ difference is that the platform turned this one off rather than the repo layout.
 Also flags workflows that have never produced a single run — one that has never
 executed is indistinguishable from one that is broken.
 
-Exit 0 = every workflow can fire.
+Exit 0 = every workflow in every repo can fire, and every repo answered.
 Exit 1 = at least one is disabled or has never run.
-Exit 2 = could not inspect (no gh, no auth) — never confused with "all clear".
+Exit 2 = could not inspect, or could not inspect enough of the estate to speak
+         for it — never confused with "all clear". That distinction was a claim
+         this file made and did not keep until 2026-08-07; see the reachability
+         floor at the bottom of main() for what it looked like when it broke.
 """
 
 import argparse
@@ -26,6 +29,17 @@ import sys
 from pathlib import Path
 
 OWNER = "mistakeknot"
+
+
+def gh_installed():
+    """Whether the `gh` binary exists. Deliberately NOT whether it can answer.
+
+    Named for what it actually establishes, because the difference is where the
+    bug was: a present `gh` with a dead token satisfies this and answers nothing,
+    and for a long time that combination reached the health surface as a pass.
+    The reachability floor at the end of main() covers the other half.
+    """
+    return subprocess.run(["which", "gh"], capture_output=True).returncode == 0
 
 
 def gh_json(path):
@@ -45,15 +59,18 @@ def gh_raw(path):
     return p.stdout if p.returncode == 0 else None
 
 
-def triggers(repo, path):
+def triggers(slug, path):
     """The event names a workflow declares, or None if they cannot be read.
+
+    Takes an `owner/repo` slug, not a bare name — see origin_slug for why a
+    directory name is not a safe stand-in for one.
 
     None rather than an empty set when the file cannot be fetched or parsed:
     "declares no triggers" and "I could not read its triggers" are different
     claims, and only the first would justify softening a verdict. Anything
     unreadable keeps the stricter reading.
     """
-    txt = gh_raw(f"repos/{OWNER}/{repo}/contents/{path}")
+    txt = gh_raw(f"repos/{slug}/contents/{path}")
     if txt is None:
         return None
     try:
@@ -76,16 +93,59 @@ def triggers(repo, path):
     return None
 
 
+def origin_slug(path: Path):
+    """The `owner/repo` this checkout actually pushes to, or None.
+
+    Read from the remote rather than assumed from the directory name, because on
+    2026-08-07 three of the estate's directories disagreed with their remote:
+
+        _shared    -> mistakeknot/interverse-shared
+        lattice    -> mistakeknot/interweave
+        intersite  -> mistakeknot/interverse-intersite
+
+    The first two 404 under their directory name, so they were quietly skipped
+    and reported as nothing at all. The third is the one that should worry you:
+    `mistakeknot/intersite` EXISTS — a different repo, last pushed 2026-04-19 —
+    while the checkout tracks `interverse-intersite`, pushed 2026-08-03. So this
+    check was inspecting an abandoned repo and reporting the result as the health
+    of the live one. Both happened to have zero workflows, which is luck, not
+    correctness: a disabled secret-scan on the real repo would have been reported
+    clean by looking somewhere else.
+
+    An unreachable name announces itself. A wrong but answerable name does not.
+    """
+    p = subprocess.run(["git", "-C", str(path), "remote", "get-url", "origin"],
+                       capture_output=True, text=True)
+    if p.returncode != 0:
+        return None
+    url = p.stdout.strip()
+    if url.endswith(".git"):
+        url = url[:-4]
+    # https://host/owner/repo and git@host:owner/repo both end in owner/repo.
+    bits = url.replace(":", "/").rstrip("/").split("/")
+    if len(bits) < 2 or not bits[-1] or not bits[-2]:
+        return None
+    return f"{bits[-2]}/{bits[-1]}"
+
+
 def estate_repos(root: Path):
-    names = []
+    """Yield (label, slug) for every checkout in the estate.
+
+    A checkout whose slug cannot be resolved yields slug None rather than being
+    dropped, so it surfaces as unreachable instead of vanishing. Nothing here is
+    allowed to leave the list silently — that is the whole lesson of this file.
+    """
+    found = []
     clav = root / "os" / "Clavain"
     if (clav / ".git").is_dir():
-        names.append("Clavain")
+        found.append((clav.name, origin_slug(clav)))
     iv = root / "interverse"
     if iv.is_dir():
-        names += sorted(c.name for c in iv.iterdir() if (c / ".git").is_dir())
-    names.append("Sylveste")
-    return names
+        for c in sorted(iv.iterdir()):
+            if (c / ".git").is_dir():
+                found.append((c.name, origin_slug(c)))
+    found.append((root.name, origin_slug(root) or f"{OWNER}/Sylveste"))
+    return found
 
 
 def main(argv=None):
@@ -96,22 +156,37 @@ def main(argv=None):
                     help="fail if fewer than N repos were inspected (vacuity guard)")
     args = ap.parse_args(argv)
 
-    if subprocess.run(["which", "gh"], capture_output=True).returncode != 0:
+    if not gh_installed():
         print("check-workflow-health: gh not available — cannot inspect", file=sys.stderr)
         return 2
 
     repos = estate_repos(Path(args.root))
+    # Two floors, against two different denominators, because two different
+    # things can go wrong. This one is the checkout: a partial clone has fewer
+    # repos on disk than the estate really has. The one after the loop is
+    # reachability, and it is the load-bearing one — see there.
     if len(repos) < args.require_repos:
-        print(f"check-workflow-health: inspected {len(repos)} repos, expected "
-              f">= {args.require_repos}. Refusing to report health on a partial "
-              f"checkout.", file=sys.stderr)
+        print(f"check-workflow-health: found {len(repos)} repo(s) on disk, "
+              f"expected >= {args.require_repos}. Refusing to report health on "
+              f"a partial checkout.", file=sys.stderr)
         return 2
 
-    disabled, never, manual = [], [], []
+    disabled, never, manual, unreachable = [], [], [], []
     inspected = 0
-    for repo in repos:
-        data = gh_json(f"repos/{OWNER}/{repo}/actions/workflows")
+    for label, slug in repos:
+        # The label is what it is called on disk; the slug is what it is on
+        # GitHub. Reporting the label alone is what hid the case where they
+        # differ, so a differing pair is printed as both.
+        repo = f"{label} ({slug})" if slug and slug.split("/")[-1] != label else label
+        if slug is None:
+            unreachable.append(f"{label} (no origin remote)")
+            continue
+        data = gh_json(f"repos/{slug}/actions/workflows")
         if data is None:
+            # Was a bare `continue` until 2026-08-07, and that was the whole bug:
+            # a repo the API could not answer for left no trace at all. See the
+            # reachability floor below for what it cost.
+            unreachable.append(repo)
             continue
         inspected += 1
         for w in data.get("workflows", []):
@@ -123,7 +198,7 @@ def main(argv=None):
             if state != "active":
                 disabled.append((repo, name, state))
                 continue
-            runs = gh_json(f"repos/{OWNER}/{repo}/actions/workflows/{w['id']}/runs?per_page=1")
+            runs = gh_json(f"repos/{slug}/actions/workflows/{w['id']}/runs?per_page=1")
             if runs is not None and runs.get("total_count", 0) == 0:
                 # A workflow_dispatch-only workflow has no automatic trigger, so
                 # "never ran" means nobody has needed it yet -- not that anything
@@ -133,7 +208,7 @@ def main(argv=None):
                 #
                 # Still reported, because unvalidated is a real thing to know
                 # about a release path. Just not a failure.
-                ev = triggers(repo, w.get("path", ""))
+                ev = triggers(slug, w.get("path", ""))
                 if ev is not None and ev <= {"workflow_dispatch"}:
                     manual.append((repo, name))
                 else:
@@ -141,20 +216,73 @@ def main(argv=None):
 
     if not args.quiet:
         for repo, name, state in sorted(disabled):
-            print(f"DISABLED  {repo:16} {name:30} state={state}")
+            print(f"DISABLED  {repo:24} {name:30} state={state}")
         for repo, name in sorted(never):
-            print(f"NEVER-RAN {repo:16} {name:30} (never validated)")
+            print(f"NEVER-RAN {repo:24} {name:30} (never validated)")
         for repo, name in sorted(manual):
-            print(f"MANUAL    {repo:16} {name:30} "
+            print(f"MANUAL    {repo:24} {name:30} "
                   f"(workflow_dispatch only; never dispatched)")
+        # Capped, because this is the one list that can be the whole estate: a
+        # dead token makes every repo unreachable at once, and 73 identical lines
+        # bury the summary that says what happened. The others cannot run away
+        # like that — a disabled workflow is news precisely because it is rare.
+        # The count below is the fact; the names are only the sample.
+        for repo in sorted(unreachable)[:8]:
+            print(f"UNREACHED {repo:24} {'':30} (the API would not answer for it)")
+        if len(unreachable) > 8:
+            print(f"UNREACHED ... and {len(unreachable) - 8} more")
 
     tail = f", {len(manual)} manual-only never dispatched" if manual else ""
-    print(f"{inspected} repo(s) inspected: {len(disabled)} disabled, "
-          f"{len(never)} never ran{tail}")
+    if unreachable:
+        tail += f", {len(unreachable)} unreachable"
+    # "N of M" rather than "N", because the gap between them is the fact a reader
+    # most needs and the one the old wording had no room to say.
+    print(f"{inspected} of {len(repos)} repo(s) inspected: {len(disabled)} "
+          f"disabled, {len(never)} never ran{tail}")
     if disabled:
         print("  re-enable: gh api --method PUT "
-              "repos/mistakeknot/<repo>/actions/workflows/<id>/enable")
-    return 1 if (disabled or never) else 0
+              "repos/<owner>/<repo>/actions/workflows/<id>/enable")
+
+    # THE FLOOR THAT MATTERS APPLIES TO WHAT WAS INSPECTED, NOT TO WHAT WAS ON
+    # DISK. Until 2026-08-07 `--require-repos` was tested only against the
+    # directory listing, and the loop that followed skipped every repo the API
+    # would not answer for. So a `gh` that was installed and on PATH but could
+    # not authenticate — an expired token, a revoked scope, a rate limit, a
+    # network flap — produced this, measured with a planted `gh` that exits 1:
+    #
+    #     0 repo(s) inspected: 0 disabled, 0 never ran
+    #     exit 0
+    #
+    # A clean pass, on the health surface, from a run that inspected nothing. The
+    # vacuity guard was pointed at the one number that could not go wrong: the
+    # repos were all still on disk. The docstring above promises exit 2 for "no
+    # gh, no auth", and the `which gh` probe at the top of main() delivered only
+    # the first half — a binary being present says nothing about whether it can
+    # answer.
+    if inspected < args.require_repos:
+        print(f"check-workflow-health: reached {inspected} of {len(repos)} "
+              f"repo(s), expected >= {args.require_repos}. A verdict on this "
+              f"few is not a verdict on the estate.", file=sys.stderr)
+        return 2
+
+    # A finding stands on its own. A disabled workflow is disabled whether or not
+    # some other repo answered, so partial coverage does not soften it.
+    if disabled or never:
+        return 1
+
+    # Nothing wrong in the repos that answered is not the same claim as nothing
+    # wrong in the estate, and exit 0 here would make the second claim. If this
+    # proves to flap on transient API failures, the fix is a retry around
+    # gh_json — not a softer verdict, which would restore exactly the bug above.
+    if unreachable:
+        shown = sorted(unreachable)[:8]
+        more = f" (+{len(unreachable) - 8} more)" if len(unreachable) > 8 else ""
+        print(f"check-workflow-health: {len(unreachable)} repo(s) could not be "
+              f"reached, so this run cannot speak for the whole estate: "
+              f"{', '.join(shown)}{more}", file=sys.stderr)
+        return 2
+
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/test_check_kimi_version_parity.py
+++ b/tests/test_check_kimi_version_parity.py
@@ -87,6 +87,39 @@ def test_unreadable_manifest_does_not_silently_pass(tmp_path):
     assert parity.main(["--root", str(tmp_path), "--require-plugins", "1"]) == 1
 
 
+def test_BOTH_manifests_unreadable_does_not_pass(tmp_path):
+    """One corrupt manifest was already covered. Two was the hole.
+
+    The check compares `got != want`, and read_version turns an unparseable file
+    into a `<unreadable: ...>` marker built from the exception text. Two files
+    that are broken the same way raise the same exception, so their markers are
+    equal, so the comparison succeeds — on a plugin whose manifests could not be
+    parsed at all. Measured before the fix: three plugins with empty manifests
+    reported `parity ok: 3 plugin(s)` and exit 0.
+
+    The test above stops one step short of this because it corrupts only the
+    generated side, leaving the canonical side readable and the two markers
+    unequal. That is why it passed throughout.
+    """
+    _plugin(tmp_path, "1.0.0", "1.0.0")
+    (tmp_path / ".claude-plugin" / "plugin.json").write_text("")
+    (tmp_path / "kimi.plugin.json").write_text("")
+    assert parity.main(["--root", str(tmp_path), "--require-plugins", "1"]) == 1
+
+
+def test_no_version_key_in_either_manifest_does_not_pass(tmp_path):
+    """None == None is not parity; it is the absence of the thing being checked."""
+    (tmp_path / ".claude-plugin").mkdir(parents=True)
+    (tmp_path / ".claude-plugin" / "plugin.json").write_text('{"name": "x"}\n')
+    (tmp_path / "kimi.plugin.json").write_text('{"name": "x"}\n')
+    assert parity.main(["--root", str(tmp_path), "--require-plugins", "1"]) == 1
+
+
+def test_an_empty_version_string_is_not_a_version(tmp_path):
+    _plugin(tmp_path, "", "")
+    assert parity.main(["--root", str(tmp_path), "--require-plugins", "1"]) == 1
+
+
 @pytest.mark.parametrize("required", [1, 60])
 def test_live_estate_is_in_parity(required):
     """The real estate, which this session brought to 0 drift."""

--- a/tests/test_check_kimi_version_parity.py
+++ b/tests/test_check_kimi_version_parity.py
@@ -120,6 +120,24 @@ def test_an_empty_version_string_is_not_a_version(tmp_path):
     assert parity.main(["--root", str(tmp_path), "--require-plugins", "1"]) == 1
 
 
+def test_an_unreadable_generated_manifest_is_not_called_a_stale_bump(tmp_path, capsys):
+    """The exit code is 1 either way here, so the REASON is the whole test.
+
+    A mutation that checks only the canonical side survived every exit-code
+    assertion in this file, because an unreadable generated manifest also fails
+    the plain `got != want` comparison and lands on exit 1 regardless. What it
+    loses is the diagnosis: it tells you the version was bumped without
+    regenerating, which sends you to run the generator on a file that cannot be
+    parsed. Wrong instruction, confidently given.
+    """
+    _plugin(tmp_path, "1.0.0", "1.0.0")
+    (tmp_path / "kimi.plugin.json").write_text("{ not json\n")
+    assert parity.main(["--root", str(tmp_path), "--require-plugins", "1"]) == 1
+    err = capsys.readouterr().err
+    assert "no readable version to compare" in err
+    assert "version bumped without regenerating" not in err
+
+
 @pytest.mark.parametrize("required", [1, 60])
 def test_live_estate_is_in_parity(required):
     """The real estate, which this session brought to 0 drift."""

--- a/tests/test_check_workflow_health.py
+++ b/tests/test_check_workflow_health.py
@@ -1,0 +1,233 @@
+"""Coverage for the estate workflow-health check.
+
+This file did not exist until 2026-08-07, and the check had been running weekly
+on zklw for a month without one. What it was missing is the reason it is here.
+
+check-workflow-health had a vacuity guard, `--require-repos`, and the guard was
+pointed at the wrong denominator: `len(repos)`, the directories on disk. The loop
+underneath it skipped any repo the GitHub API would not answer for, and nothing
+counted those skips. So a `gh` that was installed and on PATH but could not
+authenticate produced a clean pass over nothing:
+
+    0 repo(s) inspected: 0 disabled, 0 never ran
+    exit 0
+
+Measured with a planted `gh` on PATH that exits 1 for every call. The repos were
+all still on disk, so the only number the guard could see was the one number that
+could not go wrong.
+
+Fixing that surfaced the second bug immediately, which is the better one: repo
+names were assumed from directory names, and three of the estate's directories
+disagree with their remote. Two of those 404 and had been silently skipped for as
+long as the check existed. The third resolved to a REAL BUT DIFFERENT repo, so
+the check had been reporting an abandoned repo's health as the live one's.
+
+The tests below therefore care much more about verdicts than about formatting.
+Every exit code this check can return has a test that makes it happen, and — the
+part that matters — makes it happen for its own reason: a run that reached
+nothing must not be able to borrow exit 0 from a run that reached everything and
+found it healthy.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "check_workflow_health",
+    Path(__file__).resolve().parents[1] / "scripts" / "check-workflow-health.py",
+)
+wfh = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(wfh)
+
+REPOS = [f"r{i:02d}" for i in range(1, 41)]
+PAIRS = [(r, f"mistakeknot/{r}") for r in REPOS]
+
+
+@pytest.fixture(autouse=True)
+def _offline(monkeypatch):
+    """No test here touches the network or the disk layout."""
+    monkeypatch.setattr(wfh, "gh_installed", lambda: True)
+    monkeypatch.setattr(wfh, "estate_repos", lambda root: list(PAIRS))
+
+
+def _api(monkeypatch, unreachable=(), disabled=(), never=(), manual=()):
+    """Install a gh_json that answers for every repo except the named ones."""
+    def fn(path):
+        repo = path.split("/")[2]          # repos/<owner>/<repo>/...
+        if repo in unreachable:
+            return None
+        if "/runs" in path:
+            return {"total_count": 0 if repo in (set(never) | set(manual)) else 3}
+        state = "disabled_inactivity" if repo in disabled else "active"
+        return {"workflows": [{"path": ".github/workflows/ci.yml",
+                               "id": 1, "state": state}]}
+    monkeypatch.setattr(wfh, "gh_json", fn)
+    monkeypatch.setattr(
+        wfh, "triggers",
+        lambda slug, path: ({"workflow_dispatch"}
+                            if slug.split("/")[-1] in manual else {"push"}))
+
+
+def test_a_healthy_estate_passes(monkeypatch):
+    _api(monkeypatch)
+    assert wfh.main(["--require-repos", "30"]) == 0
+
+
+def test_a_disabled_workflow_is_a_finding(monkeypatch):
+    """The failure this check was written for: GitHub switched off secret-scan
+    on 17 of 36 plugin repos after 60 days of inactivity."""
+    _api(monkeypatch, disabled={"r07"})
+    assert wfh.main(["--require-repos", "30"]) == 1
+
+
+def test_a_workflow_that_never_ran_is_a_finding(monkeypatch):
+    _api(monkeypatch, never={"r07"})
+    assert wfh.main(["--require-repos", "30"]) == 1
+
+
+def test_a_manual_only_workflow_is_reported_but_is_not_a_finding(monkeypatch):
+    """Sylveste#62. A workflow_dispatch-only workflow has no trigger that could
+    have fired, so `never ran` describes it accurately and accuses it wrongly."""
+    _api(monkeypatch, manual={"r07"})
+    assert wfh.main(["--require-repos", "30"]) == 0
+
+
+def test_an_estate_that_answers_for_nothing_is_not_a_pass(monkeypatch):
+    """THE BUG. Before the fix this returned 0 and said `0 repo(s) inspected`."""
+    _api(monkeypatch, unreachable=set(REPOS))
+    assert wfh.main(["--require-repos", "30"]) == 2
+
+
+def test_reaching_fewer_repos_than_the_floor_is_not_a_pass(monkeypatch):
+    """29 of 40 with the floor at 30 — the boundary, from the failing side."""
+    _api(monkeypatch, unreachable=set(REPOS[:11]))
+    assert wfh.main(["--require-repos", "30"]) == 2
+
+
+def test_partial_coverage_above_the_floor_still_cannot_claim_the_estate(monkeypatch):
+    """30 of 40 clears the floor and is still not a verdict on 40.
+
+    Nothing wrong in the repos that answered is a different claim from nothing
+    wrong in the estate, and exit 0 makes the second one.
+    """
+    _api(monkeypatch, unreachable=set(REPOS[:10]))
+    assert wfh.main(["--require-repos", "30"]) == 2
+
+
+def test_a_finding_stands_despite_partial_coverage(monkeypatch):
+    """A disabled workflow is disabled whether or not some other repo answered.
+
+    This is the one case where partial coverage must NOT win: downgrading a real
+    finding to `could not assess` because an unrelated repo timed out would hide
+    the thing the check exists to find.
+    """
+    _api(monkeypatch, unreachable=set(REPOS[:5]), disabled={"r09"})
+    assert wfh.main(["--require-repos", "30"]) == 1
+
+
+def test_no_gh_binary_is_could_not_run(monkeypatch):
+    monkeypatch.setattr(wfh, "gh_installed", lambda: False)
+    assert wfh.main(["--require-repos", "30"]) == 2
+
+
+def test_a_partial_checkout_is_refused_before_any_api_call(monkeypatch):
+    """The other floor, against the other denominator: too few repos on disk."""
+    monkeypatch.setattr(wfh, "estate_repos", lambda root: PAIRS[:2])
+
+    def explode(path):
+        raise AssertionError("must not call the API on a partial checkout")
+
+    monkeypatch.setattr(wfh, "gh_json", explode)
+    assert wfh.main(["--require-repos", "30"]) == 2
+
+
+def test_a_checkout_with_no_resolvable_remote_is_unreachable_not_absent(monkeypatch):
+    """Slug None must surface, not vanish.
+
+    Dropping it from the list would put the check straight back into the state
+    this file exists to document: a repo that is neither inspected nor counted
+    against the coverage it claims.
+    """
+    monkeypatch.setattr(wfh, "estate_repos",
+                        lambda root: PAIRS[:39] + [("orphan", None)])
+    _api(monkeypatch)
+    assert wfh.main(["--require-repos", "40"]) == 2
+
+
+def test_a_repo_is_inspected_under_its_slug_not_its_directory_name(monkeypatch):
+    """`interverse/intersite` pushes to `mistakeknot/interverse-intersite`.
+
+    `mistakeknot/intersite` also exists — a different, abandoned repo — so an
+    inspection keyed on the directory name got a confident answer about the
+    wrong subject. The assertion is on the URL, because the failure mode here
+    produces a perfectly healthy-looking verdict.
+    """
+    asked = []
+
+    def fn(path):
+        asked.append(path)
+        return {"workflows": []}
+
+    monkeypatch.setattr(wfh, "gh_json", fn)
+    monkeypatch.setattr(wfh, "estate_repos",
+                        lambda root: [("intersite", "mistakeknot/interverse-intersite")])
+    wfh.main([])
+    assert asked == ["repos/mistakeknot/interverse-intersite/actions/workflows"]
+    assert not any("repos/mistakeknot/intersite/" in p for p in asked)
+
+
+def test_a_differing_slug_is_shown_alongside_the_directory_name(monkeypatch, capsys):
+    """Because the reader cannot check what the reader cannot see."""
+    monkeypatch.setattr(
+        wfh, "estate_repos",
+        lambda root: [("lattice", "mistakeknot/interweave")])
+    monkeypatch.setattr(wfh, "gh_json", lambda path: None)
+    wfh.main([])
+    assert "lattice (mistakeknot/interweave)" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("url,want", [
+    ("https://github.com/mistakeknot/interweave.git", "mistakeknot/interweave"),
+    ("https://github.com/mistakeknot/interweave", "mistakeknot/interweave"),
+    ("git@github.com:mistakeknot/interweave.git", "mistakeknot/interweave"),
+    ("ssh://git@github.com/mistakeknot/interweave.git", "mistakeknot/interweave"),
+])
+def test_origin_slug_parses_the_url_forms_git_actually_emits(monkeypatch, url, want):
+    class R:
+        returncode = 0
+        stdout = url + "\n"
+
+    monkeypatch.setattr(wfh.subprocess, "run", lambda *a, **k: R())
+    assert wfh.origin_slug(Path("/nowhere")) == want
+
+
+def test_origin_slug_is_none_when_git_cannot_answer(monkeypatch):
+    class R:
+        returncode = 128
+        stdout = ""
+
+    monkeypatch.setattr(wfh.subprocess, "run", lambda *a, **k: R())
+    assert wfh.origin_slug(Path("/nowhere")) is None
+
+
+def test_the_summary_says_how_many_of_how_many(monkeypatch, capsys):
+    """The gap between reached and expected is the fact a reader most needs.
+
+    The old wording had no room to say it: `0 repo(s) inspected` reads as a
+    complete sentence about a healthy estate if you are skimming.
+    """
+    _api(monkeypatch, unreachable=set(REPOS[:10]))
+    wfh.main(["--require-repos", "30"])
+    assert "30 of 40 repo(s) inspected" in capsys.readouterr().out
+
+
+def test_the_unreachable_list_is_capped(monkeypatch, capsys):
+    """A dead token makes every repo unreachable at once, and 40 identical lines
+    bury the summary that explains why."""
+    _api(monkeypatch, unreachable=set(REPOS))
+    wfh.main(["--require-repos", "30"])
+    out = capsys.readouterr().out
+    assert out.count("UNREACHED") <= 9          # 8 names plus the elision line
+    assert "and 32 more" in out

--- a/tests/test_check_workflow_health.py
+++ b/tests/test_check_workflow_health.py
@@ -120,6 +120,38 @@ def test_partial_coverage_above_the_floor_still_cannot_claim_the_estate(monkeypa
     assert wfh.main(["--require-repos", "30"]) == 2
 
 
+def test_the_floor_outranks_a_finding_when_coverage_collapses(monkeypatch):
+    """15 of 40 with a disabled workflow among them is still exit 2, not 1.
+
+    This is the ONLY test that can tell the two floors apart, and it exists
+    because a mutation proved the others could not. Every other scenario has
+    `unreachable` non-empty, and the unreachable check returns 2 as well — so
+    swapping the floor back to `len(repos)`, which IS the original bug, left the
+    whole suite green. Here the mutation changes the answer: with the floor on
+    the directory listing, 40 >= 30 passes, the finding is reported, and exit 1
+    claims a verdict drawn from a third of the estate.
+
+    Order matters and this pins it: a finding you cannot situate is not a
+    verdict. 25 unreachable repos might hold twenty more of the same.
+    """
+    _api(monkeypatch, unreachable=set(REPOS[:25]), disabled={"r30"})
+    assert wfh.main(["--require-repos", "30"]) == 2
+
+
+def test_one_unresolvable_checkout_is_enough_to_withhold_a_verdict(monkeypatch):
+    """40 healthy repos plus a single orphan is not an all-clear.
+
+    Also written because a mutation survived: the earlier orphan test put the
+    floor exactly at the repo count, so dropping the orphan failed the floor
+    instead of failing the thing under test. Here coverage clears the floor
+    easily, so the orphan is the only reason the verdict is withheld.
+    """
+    monkeypatch.setattr(wfh, "estate_repos",
+                        lambda root: PAIRS + [("orphan", None)])
+    _api(monkeypatch)
+    assert wfh.main(["--require-repos", "30"]) == 2
+
+
 def test_a_finding_stands_despite_partial_coverage(monkeypatch):
     """A disabled workflow is disabled whether or not some other repo answered.
 

--- a/tests/test_check_workflow_health.py
+++ b/tests/test_check_workflow_health.py
@@ -44,6 +44,10 @@ _SPEC.loader.exec_module(wfh)
 REPOS = [f"r{i:02d}" for i in range(1, 41)]
 PAIRS = [(r, f"mistakeknot/{r}") for r in REPOS]
 
+# Captured before the autouse fixture below replaces it, for the one test that
+# is about estate_repos itself rather than about what main() does with it.
+REAL_ESTATE_REPOS = wfh.estate_repos
+
 
 @pytest.fixture(autouse=True)
 def _offline(monkeypatch):
@@ -201,6 +205,19 @@ def test_origin_slug_parses_the_url_forms_git_actually_emits(monkeypatch, url, w
 
     monkeypatch.setattr(wfh.subprocess, "run", lambda *a, **k: R())
     assert wfh.origin_slug(Path("/nowhere")) == want
+
+
+def test_a_relative_root_still_yields_a_named_repo(monkeypatch, tmp_path):
+    """Path(".").name is the empty string, and `--root .` is an ordinary call.
+
+    Unresolved, the monorepo's own entry printed with a blank label — which
+    reads as a formatting glitch rather than as the missing name it is.
+    """
+    monkeypatch.setattr(wfh, "origin_slug", lambda p: "mistakeknot/Sylveste")
+    monkeypatch.chdir(tmp_path)
+    labels = [label for label, _ in REAL_ESTATE_REPOS(Path("."))]
+    assert labels == [tmp_path.resolve().name]
+    assert "" not in labels
 
 
 def test_origin_slug_is_none_when_git_cannot_answer(monkeypatch):


### PR DESCRIPTION
Both estate checks had run green for weeks. Neither had a test asking whether the green meant anything. Each was probed by planting a target in the failing state and watching the surface — and the first fix surfaced the second bug within a single run.

## 1. A vacuity guard pointed at the one number that could not go wrong

`check-workflow-health` took `--require-repos` and tested it against `len(repos)` — the directory listing. The loop underneath skipped any repo the GitHub API would not answer for, and counted nothing when it did. So a `gh` that is installed and on PATH but cannot authenticate produced this, measured with a planted `gh` that exits 1 for every call:

```
0 repo(s) inspected: 0 disabled, 0 never ran
exit 0
```

A clean pass, on the health surface, from a run that inspected nothing. The guard could not catch it because the repos were all still on disk — the only number it was allowed to see was the one that never moves. The file's own docstring promised exit 2 for "no gh, no auth", and the `which gh` probe delivered the first half only.

The floor now applies to what was reached. Partial coverage above the floor is also not a pass, because nothing wrong in the repos that answered is a different claim from nothing wrong in the estate. A real finding still stands regardless.

## 2. The check was inspecting the wrong repo

Fixing (1) immediately reported `_shared` and `lattice` as unreachable. Neither is an outage — repo names were derived from **directory names**, and three estate directories disagree with their remote:

| directory | actually pushes to |
|---|---|
| `_shared` | `mistakeknot/interverse-shared` |
| `lattice` | `mistakeknot/interweave` |
| `intersite` | `mistakeknot/interverse-intersite` |

The first two 404 and had been silently skipped since the check was written. The third never appeared as unreachable at all, and it is the one that matters: **`mistakeknot/intersite` exists** — a different repo, last pushed 2026-04-19 — while the checkout tracks `interverse-intersite`, pushed 2026-08-03. The check was reporting an abandoned repo's health as the live one's. Both happen to carry zero workflows, which is luck, not correctness: a disabled `secret-scan` on the real repo would have been reported clean by looking somewhere else.

An unreachable name announces itself. A wrong but answerable name does not.

Names now resolve from each checkout's origin remote; an unresolvable slug surfaces as unreachable rather than vanishing; a slug that disagrees with its directory prints as both.

## 3. A comparison that can be satisfied by absence

`check-kimi-version-parity` compares `got != want`, and equality is the wrong test the moment both sides can be absent. Two manifests that each lack a `version` key both read `None`; `None == None`; parity is declared on the strength of a field neither file has. Two *unreadable* manifests are worse — they fail identically, so their `<unreadable: …>` markers match. Measured: three plugins with empty manifest files, `parity ok: 3 plugin(s)`, exit 0.

The existing suite stopped one step short: it corrupts the generated manifest and leaves the canonical one readable, so the markers differ. One corrupt file was covered. Two was the hole.

## Verification

- **36 assertions** across both suites; **127 passed** across all of `tests/`.
- `tests/test_check_workflow_health.py` is new — the check had been running weekly on zklw for a month with no test at all.
- **17 mutations, 0 survivors.** Three survived the first pass, and one of them was the original bug: every reachability test had `unreachable` non-empty, so the unreachable branch returned 2 first and putting the `len(repos)` floor back left all 33 assertions green. The distinguishing case — coverage below the floor *with a finding inside it* — is now pinned.
- Real estate after the fix: **73 of 73 repos inspected**, 0 disabled, 0 never ran, 1 manual-only, exit 0. The old code reported 71 and exited 0 without saying which two it had dropped.

## Not in this PR

- **The `--require-plugins 55` floor.** Clavain carries 70 plugins, zklw 66. On the same day zklw reported `parity ok: 66`, Clavain found real committed drift in `interlore` — both honest runs, looking at different estates. 55 was chosen when the estate was 62 and now permits 15 plugins to be missing without comment. Raising it is a claim about how complete a checkout is *required* to be, which is mk's call.
- **The `interlore` drift itself** was fixed independently in that repo while this was in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HRp5jKGv3mQPp1dCVfF5He
