### PR TITLE
docs: regenerate roadmap and backlog with the de-forked generator

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,7 +1,7 @@
 # Sylveste Backlog - Detailed Inventory
 
 **Companion to:** [sylveste-roadmap.md](sylveste-roadmap.md) (strategic roadmap)
-**Last synced:** 2026-07-13
+**Last synced:** 2026-08-08
 
 This file contains every live P2-P4 item in the canonical Beads tracker.
 It is generated from [roadmap.json](roadmap.json); do not hand-edit it.
@@ -10,83 +10,531 @@ It is generated from [roadmap.json](roadmap.json); do not hand-edit it.
 
 ## P2 - Next
 
-### Demo
-- **shadow-work-0ql** Build and package Tauri desktop binary
+### a2a
+- **sylveste-ewy3.4.1.4** OAuth2 Resource Indicators authentication on /messages + /tasks _(blocked)_
 
-### Epic
-- **shadow-work-ac5b** 2025-2525 scenario planning — Generate and refine issue corpus
-- **shadow-work-fmw0** Graduating Narrative Judge — seed gate + LLM judge + trained classifier for Level 4 validation
-- **shadow-work-o79m** Scenario authoring — Playable game content from ARCHITECTURE specs
-- **shadow-work-t84f** Refactor hot paths and structural debt
+### auraken
+- **sylveste-0rmf** Prompt-injection defense for external content (2-of-3 verdict combiner)
+- **sylveste-2l1.4** Build anchor scenario regression suite from daily_dilemmas
+- **sylveste-2l1.5** Extract REDDIT_threaded sample (5K posts) for coverage index
+- **sylveste-2l1.6** AITA near-miss density analysis (270K moral dilemmas)
+- **sylveste-muf** Research: ambient recommendation UX — window shopping vs. over-indexed personalization _(deferred)_
 
-### Post-v1
-- **shadow-work-7xs** Web distribution — adaptive agent scaling (Phase 2)
-- **shadow-work-nla** Web distribution — WASM with threaded simulation (Phase 1)
-- **shadow-work-sfj** Additional scenarios
-- **shadow-work-v4r** Agent recruitment system
-- **shadow-work-y03** Deepen the gameplay loop
-- **shadow-work-y86** Save/load system
+### clavain
+- **sylveste-clha** Build /clavain:office-hours adversarial pre-plan gate (gstack import)
+- **sylveste-dan6** Design remote signer or canonical ledger replication for Mac-originated operations
+- **sylveste-lfru** Wire /clavain:ship -> interpath:changelog + interdoc + interwatch:refresh chain
+- **sylveste-otv9** Retire ambiguous home-ledger fallback without losing historical runs
+
+### epic
+- **sylveste-bcok** interop: Notion + Auraken + Clavain + GitHub integration bridge
+
+### fd
+- **sylveste-u9cp** INSTALL.md must lead with encounter framing, not capability enumeration; add substrate-readiness scan _(blocked)_
+- **sylveste-zjz3** install.sh step 6 must be a transmissive close, not capability enumeration _(blocked)_
+
+### harvest
+- **Sylveste-ie6.7** Transplant Compound's Codex Writer safety logic into Clavain's Codex install path
+
+### infra
+- **Sylveste-6f7** zklw Go toolchain (1.23.8) too old to build intercore (go 1.25.0) + darwin release binaries — blocks canary-registering ic and Clavain publish from zklw
+- **Sylveste-bzy** 5 interverse plugins dual-tracked: force-added into monorepo AND published from independent repos (interfer, interhelm, intersight, interseed, intership)
+
+### intercore
+- **Sylveste-nwv** ic publish: adopt 'claude plugin tag' release tagging + plugin dependency metadata + projected context cost surfacing
+
+### interfer
+- **Sylveste-0gi** DeepSeek V4 Flash on flash-moe — port effort vs wait-for-hardware decision
+- **Sylveste-2ss** Flash-MoE holistic benchmark suite — quality, latency, memory, reliability _(blocked)_
+- **Sylveste-6ru** Qwen3.6-35B-A3B quantization sweep (DWQ vs nvfp4 vs OptiQ vs plain) _(blocked)_
+- **Sylveste-bov** flash-moe decode regression — 5 tok/s actual vs 12.9 tok/s spec
+- **sylveste-dczo** Promote Track B5 to enforce mode _(blocked)_
+- **Sylveste-ep8** Evaluate Qwen3.6-27B-OptiQ-4bit (released 2026-04-25) _(blocked)_
+- **Sylveste-wfz** Fix test_polar_transform_range TurboQuant test failure
+- **sylveste-yfot** Benchmark speculative decoding with 9B draft model _(deferred)_
+
+### interfer 2ss
+- **Sylveste-r8g** Add SWE-bench Lite runner to code_correctness harness _(blocked)_
+
+### interfer+interflux
+- **Sylveste-k8c** Local inference backend for flux-review agents — server-mode bridge _(blocked)_
+
+### interfere
+- **sylveste-m71** Publish Pareto frontier analysis: speed vs quality across local models _(blocked)_
+- **sylveste-qbv** Experiment: LayerSkip / self-speculative early exit
+
+### interflux
+- **sylveste-9lp.15** P2: Structured disagreement as first-class output — disagreement_profile in findings schema
+- **sylveste-9lp.17** P2: Passage-level citation in research synthesis — attribute claims to source passages, not agents
+- **sylveste-9lp.18** P2: Evaluation rubrics — track finding recall, precision, coverage over time
+- **sylveste-9lp.19** P2: Difficulty-aware slot ceiling — replace static formula with content-signal estimator _(blocked)_
+- **sylveste-9lp.20** P2: Embedding-based dedup pass — cosine similarity on finding titles for conceptual duplicates
+- **sylveste-9lp.21** P2: Typed agent-state log — JSONL per agent replacing in-prompt state tracking
+- **sylveste-9lp.22** P2: Trust model diagnostics — explain low scores and feed back into prompt tuning
+- **sylveste-9lp.32** BP-C1: lib_registry.py + registry-write consolidation (5 atomic-mutate sites + scoring algorithm extraction)
+- **sylveste-9lp.32.7** BP-C1.C: extract scripts/_fluxbench_score.py from fluxbench-score.sh heredoc (180 lines)
+- **sylveste-9lp.33** BP-C3: sanitize_untrusted.py fuzz tests + TrustedContent NewType — full 4-channel integration
+- **sylveste-9lp.35** BP-C2: explicit dispatch state machine + VerificationStep primitive + run_uuid + decisions.log _(blocked)_
+- **sylveste-9lp.35.6** BP-C2.B: run_uuid quire-mark + decisions.log per-run
+- **sylveste-9lp.37** Holdout Register — name the ground-truth source for every calibration loop _(blocked)_
+- **sylveste-fyo3.6** P2: Hard budget enforcement mode — test and enable blocking behavior
+- **sylveste-lrnk** Editor-of-record protocol for shared design-doc sections + n6zw close-predicate
+- **sylveste-wyoi** Brainstorm-to-roadmap lift discipline — checklist step in /interpath:roadmap
+
+### interlab
+- **sylveste-4jmp** Make plugin quality sweep read-only and reproducible
+
+### interline
+- **Sylveste-nko** Exploit new display surfaces: MessageDisplay hook, terminalSequence, subagentStatusLine effort field
+
+### intermux
+- **Sylveste-oqo** Replace session scraping with native 'claude agents --json' (2.1.145) + agent view integration
+
+### interspect
+- **sylveste-sfhq** Telemetry fusion: wire tool-time stats into interspect evidence
+
+### interstat+galiana
+- **sylveste-z7zh** Landed-work recap report (Goodhart-aware)
+
+### interverse
+- **Sylveste-ktz** Post-baseline small-fix bundle: date -d fallbacks (Sylveste-a3a) + ic publish --cwd hard-error (Sylveste-1zu) + legacy /tmp sideband retirement (Sylveste-zlc)
+
+### interwatch
+- **sylveste-mxns** 6 doc(s) drifted from source (weekly scan)
+
+### microrouter
+- **sylveste-5p7s** F2: D2 heuristic-baseline measurement — sibling to .19.9, parallel-runnable _(deferred)_
+- **sylveste-s3z6.19.5** Resolver integration in Clavain — wire into routing.yaml _(blocked)_
+- **sylveste-s3z6.19.6** Privacy-routing extension — sensitive tasks always engage router _(blocked)_
+
+### routing
+- **Sylveste-2bg** Re-measure heuristic coverage after agent-roles.yaml extension _(blocked)_
+
+### spike
+- **Sylveste-0gi.2** DeepSeek V4 → flash-moe 5-day feasibility spike (C-prime)
+
+### spike-pivot
+- **Sylveste-0gi.2.7** RunPod H200 rental for DeepSeek V4 baseline logit capture (Day-3 unblock)
 
 ### sylveste
-- **Revel-8nr** Game feel: player direction + spatial meaning
-- **shadow-work-3ek3** Test: Completeness gap validation _(in progress)_
-- **shadow-work-eby1** Scenario Assertion Protocol — canonical crisis scenarios with pressure threshold targets for L3 maturity
-- **shadow-work-t84f.1** De-hotpath and split OptimizedDataTable
-- **shadow-work-t84f.3** Reduce per-tick country snapshot cloning in simulation loop
-- **shadow-work-t84f.4** Narrow GameService and diagnostics reads to avoid whole-state clones
-- **shadow-work-t84f.5** Consolidate emergence data hooks into shared event-driven state
-- **shadow-work-th9z** TUI: Alert banner and auto-pause interrupt
-- **shadow-work-xjop** Epic: Forecasted Timeline System Tracing adapter for Shadow Work
+- **sylveste-00qu** beads: 3 UX/correctness issues (bd dolt push help-on-no-remote, missing embedded-DB bootstrap from issues.jsonl, persistent 0755 permission warning)
+- **sylveste-05rf** Auraken lens cleanup: cross-referencing pairs that may be authoring drift not distinct lenses
+- **Sylveste-06i** Ecosystem research scan: 31-component research-possibilities agenda (3 lenses) _(in progress)_
+- **Sylveste-06i.2** MAST-taxonomy classification pass over interflux/interlock failure logs
+- **Sylveste-06i.3** Covert-channel / steganographic collusion audit for interlock messaging
+- **sylveste-06yf** Refactor interfer onto MCP SDK or scope out of consolidation (prereq for sylveste-7505)
+- **sylveste-0h8** Competitive Landscape: Close Clavain routing gaps vs LiteLLM/OpenRouter
+- **Sylveste-0pk** /model-routing economy|quality seds flatten routing-table v2 phase overrides
+- **sylveste-104h** Skaffen evidence contract — consume Clavains proven schema (add run_id attribution) _(blocked)_
+- **sylveste-10na** F9: E2E install smoke + compatibility_evidence transcripts _(blocked)_
+- **sylveste-129h** Cache-corrected cost-per-landable-change as second-line north-star
+- **sylveste-18a.10** Two-stage LLM bash safety classifier for Skaffen trust evaluator
+- **sylveste-18a.11** Persistent agent memory system for Skaffen
+- **sylveste-18a.12** MCP HTTP/SSE transport for Skaffen
+- **sylveste-18a.3** Fork subagent cache optimization for parallel OODARC spawns
+- **sylveste-18a.5** Permission bubble mode for nested Skaffen agent chains _(blocked)_
+- **sylveste-1j30** F7: interlens MCP adapter — swap JSON backend to ontology-queries _(blocked)_
+- **sylveste-1mb8** Auraken-Hermes: cross-provider validation (does selector transfer beyond Claude?)
+- **sylveste-1nvc** Generic thinker-profile extraction pipeline _(blocked)_
+- **sylveste-2131** F1: Core daemon + event bus (SyncJournal, CollisionWindow, AncestorStore) _(blocked)_
+- **sylveste-22oi.3** Auraken v0.2: GPG signing pipeline for checksums.txt.asc
+- **sylveste-22oi.7.3** Cognitive profile: extraction pipeline (trajectory + conversation -> entities) _(blocked)_
+- **sylveste-22oi.7.4** Cognitive profile: auraken-profile MCP server (mirror auraken-lens) _(blocked)_
+- **sylveste-22oi.7.5** Cognitive profile: epistemic engine (promotion + half-life decay + harpoon test) _(blocked)_
+- **sylveste-22oi.7.7** Cognitive profile: pattern-awareness SKILL behaviors (Journeys 2/7/21 + harpoon hook) _(blocked)_
+- **sylveste-2fhj** rig-hook-wiring.py is tracked but declared in neither installer and not in the health surface
+- **Sylveste-2fu3** shadow-work: 17-line hook repair awaiting mk's commit in a third-party-org repo
+- **sylveste-2o0s** Add flux-review ephemeral read-only mode and cost controls
+- **sylveste-2xzz** Thinker-profile schema v1 (YAML + validation harness)
+- **Sylveste-2ys** clavain create-agent-skill command references a missing skill
+- **sylveste-301b** Diagnose interstat tool_selection_events ↔ agent_runs session_id join gap
+- **sylveste-34r2** F5.2: Go-Python persistent worker bridge _(blocked)_
+- **sylveste-35x5** Migrate interlens to high-level MCP TS SDK (prereq for sylveste-7505)
+- **sylveste-39p5** F5: TypeScript plugin adapters (interfluence,interlens,interrank,tuivision) _(blocked)_
+- **sylveste-3v97** F1: Bundle scaffolding + MANIFEST.yaml v1 schema (auraken-distribution v0.1) _(blocked)_
+- **sylveste-3xgz** Fresh-session remeasure: validate ~1,482b skill_listing reduction from sylveste-zppj
+- **sylveste-3xl3.1.19** F6.2: Run live A/B benchmark on flux-explore-teams-brainstorm-{adjacent,distant}.json corpus
+- **sylveste-3xl3.1.23** F5.3: Resolve teammate session UUIDs from team config + project session JSONLs
+- **sylveste-3xl3.1.24** F4.6: Inbox-as-transcript adapter for team_synthesize.py finalize
+- **sylveste-3xl3.1.25** F4.7: Pre-allow Bash mkdir/Write/Read for teammates in flux-explore --teams
+- **sylveste-3xl3.2** flux-drive convergent finding triangulation via agent teams
+- **sylveste-3xl3.3** /clavain:debate + intermonk:dialectic agent-teams upgrade
+- **sylveste-3xl3.4** Wire TeammateIdle/TaskCreated/TaskCompleted hooks into Interspect evidence pipeline
+- **sylveste-3xl3.7** flux-explore --teams Approach 2: target-mode review-debate _(blocked)_
+- **sylveste-3z91** F4: interspect activation CLI (per-subsystem + fleet rollup) _(deferred)_
+- **Sylveste-41r** Wire OPENROUTER_API_KEY into openrouter-dispatch MCP server env
+- **Sylveste-4b5.10** LLM-judge bias doc-hygiene + gate-hardening rider (no new judge epic)
+- **Sylveste-4b5.12** Audit-plane correlation layer (deferred, three-feed + consumer gated)
+- **Sylveste-4b5.13** Trust-card: glanceable per-task human review surface from existing evidence
+- **Sylveste-4b5.14** ACE coding-skill playbook vs compound-baseline bake-off (measurement-gated spike) _(blocked)_
+- **Sylveste-4b5.15** Pass@k harness extension + kill-gated test-time-compute scaling spike _(blocked)_
+- **Sylveste-4b5.16** Skaffen compaction verification + context-rot working-set instrumentation _(blocked)_
+- **Sylveste-4b5.5** Ground review verdict in concrete pass/fail signal (downgrade unverified 'clean') _(blocked)_
+- **Sylveste-4b5.6** Wire clavain policy engine into a real fail-CLOSED PreToolUse interdiction hook _(blocked)_
+- **Sylveste-4b5.7** Pre-dispatch parallelizability + cost gate folded into the 3kol Rimsky spec
+- **Sylveste-4b5.8** Conflict-economics telemetry on the parallel dispatcher (Rimsky, child of 3kol)
+- **Sylveste-4b5.9** campaign.md route-to-fallback-on-verified-failure (replace blind retry/skip/abort) _(blocked)_
+- **sylveste-4li0** interop: daemon adapter construction from config
+- **sylveste-4rwh** Add Break stage to trust lifecycle (Earn → Compound → Break → Epoch → Demote)
+- **Sylveste-4vol** secret scanner: the X_SECRET_Y= class still slides past the generic rule
+- **sylveste-4wq6** Extend auraken-lens trajectory schema: capture lenses_offered + user question choice (training signal) _(blocked)_
+- **sylveste-5boi** Signal command: log (recent forge sessions)
+- **sylveste-5hx7** Signal command: diff (re-show pending changes)
+- **sylveste-5jn8** Auraken lens_select latency: 12-20s per call is real UX cost (dogfood finding)
+- **sylveste-5lla** Load-path independence audit of the evidence-infra ring
+- **Sylveste-65j** Record generating-model provenance in flux-drive fd-* output format
+- **Sylveste-6ko4** Re-measure auto-stop-actions timeout rate once clavain 0.6.294 is resolved in-session
+- **sylveste-6m1k** F3: interserve-ts adapter framework _(blocked)_
+- **sylveste-6zhe** Add Sylveste affected-module build and test runner
+- **sylveste-7505** Consolidated interverse MCP server _(blocked)_
+- **sylveste-7aj8** Interspect skill calibration
+- **sylveste-7aj8.9** interspect skillcal: collector coverage — no_redirect/tokens drop ~97% of rows
+- **sylveste-7g96** F3: Prebuilt auraken-lens Go binaries for 4 platforms (v0.1.0) _(blocked)_
+- **sylveste-7zw2** Implement generated-agent retention, pack-scoped loading, and stale index refresh
+- **Sylveste-84by** git-autosync-promote reports NEEDS-REBASE for lanes that are strict ancestors of main
+- **sylveste-8tfd** Two hook scripts are present on both machines and registered nowhere
+- **sylveste-8ucm** F5.3: Core query templates (4 pure queries) _(blocked)_
+- **Sylveste-8umf** Unknown clavain-cli flags are silently ignored instead of rejected
+- **sylveste-9g6v** F2: Beads adapter — bidirectional bd CLI sync _(blocked)_
+- **Sylveste-9yoh** intercore: ic sweep — wire the 4 implemented-never-wired subsystems (scheduler engine, stall detector, RecoverPending, audit chain) with per-subsystem witness obligations (f-158)
+- **sylveste-a4oj** Multi-axis improvement: usability, token efficiency, ML-routing replacement (flux-review 2026-05-04) _(blocked)_
+- **sylveste-a4oj.9** Phase 2 — Dirty-bit and routing replacement infrastructure (S-difficulty bundle)
+- **sylveste-am7w** Meadows profile (validation anchor — 12 leverage points rediscovery test) _(blocked)_
+- **sylveste-b1ha** Persona/lens database: unify fd-agents + Auraken lenses
+- **sylveste-benl.11** Decommission Auraken Python runtime
+- **sylveste-bvoy** publish drift: shipped artifact behind committed source (2026-08-02)
+- **Sylveste-byw** interhelm/intersight: resolve dual tracking between umbrella and standalone repos
+- **Sylveste-c7a** interline: interphase sideband writer redundancy — cutover checklist for interphase retirement
+- **Sylveste-cayt** Clavain: gate-mode 3-file fix — unify bash/Go defaults, emit gate_mode_resolved via ic events record, write failure-direction policy into contracts/ (f-101/f-102/f-108)
+- **sylveste-cnxf** Redesign gsvdotcom: ACRNM-inspired technical document aesthetic
+- **sylveste-cqa** Port interblog content collections to /blog/ with one-way sync
+- **Sylveste-d3m** Adopt --to auto --class across Clavain dispatch (phase 1: shadow wiring)
+- **sylveste-dd6t** Rate limiting for forge code commands
+- **Sylveste-ddp3** rig-hook-wiring.py and rig-hook-duplication.py are tracked but declared in neither installer
+- **sylveste-dsbl** F3: Schema + DDL migration 001 — 7-entity ontology with all G3-G9 fields locked _(blocked)_
+- **sylveste-dvu** Unified user identity: composite identity table
+- **Sylveste-dvw** Research spike: execute pre-registered F6b flux-drive triage A/B (sylveste-g939)
+- **sylveste-dz94** Run test-conversations.md acceptance on Claude-family models (Opus + Haiku) _(blocked)_
+- **sylveste-e8te** F5: INSTALL.md + canonical two-step install path _(blocked)_
+- **Sylveste-e9c** Make beads post-merge handler run 'bd import' so git pull auto-syncs Dolt (real fix behind the sync-guard advisory)
+- **sylveste-ewy3.1.1** Temporal Cloud dev namespace setup + credentials path
+- **sylveste-ewy3.1.2** Wire first Skaffen test-dispatch as Temporal Workflow + mirror to Intercore event log
+- **sylveste-ewy3.1.3** Mythos+1mo decision gate: Temporal full-migration vs. dual-path
+- **sylveste-ewy3.2.1** OTEL alignment audit + feature-flagged emission in interspect-evidence.sh _(blocked)_
+- **sylveste-ewy3.2.2** Langfuse Cloud Hobby setup + 14-day dual-write spike from interspect-evidence
+- **sylveste-ewy3.2.3** Mythos+1mo decision gate: Langfuse primary vs SQLite + Langfuse shadow
+- **sylveste-f314** Appleton profile (structure-rich corpus test) _(blocked)_
+- **sylveste-fa1m** Gmail purchase import pipeline (fbz successor)
+- **sylveste-fd7x.7** Resolve intersite plugin repository remote/publish target _(blocked)_
+- **sylveste-fij2** F5: Local filesystem adapter — fsnotify, SHA-256 change detection _(blocked)_
+- **Sylveste-fsdy** Two hook scripts are present on both machines and registered nowhere
+- **Sylveste-g1cu** publish drift: shipped artifact behind committed source (2026-08-03)
+- **sylveste-g939** F6b: flux-drive triage backend swap + A/B execution + ship decision _(blocked)_
+- **sylveste-gd3q** Repackage Interspect and consolidate evidence telemetry boundaries
+- **sylveste-gfp2** Style mirroring for early conversations (pre-fingerprint)
+- **Sylveste-gtqg** New plugin repos start unprotected — nothing enforces the branch-protection policy as an invariant
+- **Sylveste-hni3** Clavain: SYLVESTE_EXEMPLAR_ROOT detection helper routed through ensure_repo, codex-auto-refresh, check-install-updates (f-084/f-085/f-052)
+- **Sylveste-hvkl** dotfiles vendors obra/superpowers as a split tree — pin an upstream ref instead?
+- **sylveste-i0px** Auraken thinker-profile system (proprietary reasoning moat) _(blocked)_
+- **sylveste-i8gp** Evidence pipeline wiring — activate sylveste-xcn4 and close the flywheel _(blocked)_
+- **sylveste-islh** F3: Interspect activation aggregator (race-fixed cursor + dedup) _(deferred)_
+- **sylveste-j0yv** F5.5: Shared resolution primitives _(blocked)_
+- **sylveste-j7gy** F5: Plugin manifest annotations + 5-plugin reference adoption _(deferred)_
+- **sylveste-j7vl** cc-changelog: unreviewed Claude Code releases (2.1.216 → 2.1.220)
+- **sylveste-jqxf** AI Factory Wave 1 foundation (ysxe successor)
+- **sylveste-jum2** Precompile interrank TypeScript at publish time (drop tsx runtime) _(blocked)_
+- **Sylveste-keb3** Six beads differ between the machines in ways no import can reconcile
+- **Sylveste-kp9o** Khouri lane frozen 109 days — mk to decide on f985d94
+- **Sylveste-kq4** Interband sideband parity from sprint-advance _(in progress)_
+- **sylveste-lbvq** F4: Python plugin adapters (intercache,interdeep,interfer,interject,intersearch,interseed) _(blocked)_
+- **sylveste-lf3b** Rename fd-agent personas with misleading lexical-prefix collisions
+- **sylveste-lfdy.1** Wire jetty.io as eval substrate for Auraken voice + behavioral signature scoring _(blocked)_
+- **sylveste-llen** Strengthen natural-language feedback loop for self-improvement
+- **sylveste-lny4** Self-dispatch loop for AI factory (ysxe.3 successor)
+- **sylveste-lon1** Cross-model dispatch scoring + integration (9lp.9 successor)
+- **sylveste-lwp7** lattice: apply_lifecycle_transition mutates et.families in registered EntityType
+- **sylveste-m2p** F4: Garden Salon agent bridge for interseed _(blocked)_
+- **sylveste-m36b** F6: SKILL.md curation + voice-rubric.md (Mandatory Form / Permitted Variation) _(blocked)_
+- **sylveste-mblb** F2: Subsystem emit helper (Go + bash) with durable session sentinel _(deferred)_
+- **sylveste-mj11.1** Hallmark log: immutable advancement_events table for trust-tier transitions
+- **sylveste-mj11.2** Tier-weight aggregation specification + conflict-resolution rule
+- **sylveste-mj11.3** Interspect substrate-independence and suhba-window classification per subsystem
+- **sylveste-mj11.4** Break invariant tuple schema and per-subsystem calibration
+- **sylveste-mj11.5** Break Synaxis cadence + chain-of-custody schema + axis-set publication
+- **sylveste-mj11.6** Dormancy/degradation rubric, Bauschinger-positive demotion, tarbiya pathway, non-conformance disposition
+- **sylveste-npc5** Repair stale Claude plugin commit metadata during deploy
+- **sylveste-nr6x.4** L4: Signal-native tool approval transport
+- **sylveste-nr6x.5** L5: Skaffen integration — sovereign agent lifecycle
+- **sylveste-nyx** Hidden /about page with mission/vision from GSV identity repo
+- **sylveste-o8wo** Fix subagent Write permission for flux-gen-specs and docs/research/flux-* directories
+- **sylveste-oej5** F10: auraken-lens Go CLI binary wrapper (cmd/auraken-lens) _(blocked)_
+- **sylveste-owjn.3** Extend observation.Snapshot to a true superset (artifacts map + phase-advance history) so ic situation snapshot fully replaces lib-sprint.sh ad-hoc queries
+- **Sylveste-oxcv** A negative-control proof cannot tell 'assertion failed' from 'fork failed', so 7 of 9 results are unknown
+- **sylveste-p6so** F8: GitHub release auraken-distribution/v0.1.0 + signed checksums + CHANGELOG _(blocked)_
+- **sylveste-pexq** Audit Python MCP servers for lazy top-level imports _(blocked)_
+- **sylveste-pf4** intersite-blog: blog fold-in + full pipeline enforcement
+- **sylveste-pfi** F5: Signal feeds + graduation workflow _(blocked)_
+- **sylveste-q2k** F6: Autonomy ratchet state machine _(blocked)_
+- **Sylveste-qgvl** intercore: wire audit chain to gate-mode resolutions + dispatch transitions (run-scoped chains, LogQ tx variant, checksum policy v2 — f-188)
+- **sylveste-qhn1** interverse hygiene: root go.work + 3 READMEs + DEPENDENCIES.md + HOOKS-REGISTRY.md
+- **Sylveste-qm2** interlock tier-2: embedding-based semantic conflict detection in pre-edit hook
+- **sylveste-qroh** F6: interrank TASK_DOMAIN_MAP FluxBench integration _(blocked)_
+- **Sylveste-r3xs** Adopt --to auto --class at remaining dispatch call sites (phase 1.5)
+- **Sylveste-rgj** Research spike: null test — does multi-agent coordination beat single-strong-model on our task mix?
+- **Sylveste-rhw** Route charter-vs-plain-goal from goal risk properties (wire classifyComplexity + spend signal into the goal-form fork)
+- **sylveste-rom** Full pipeline enforcement: MDX stripping, HMAC webhook, preview gating
+- **sylveste-rsj** EPIC: Sylveste SOTA — Garden Salon Architecture
+- **sylveste-rsj.3** Roguelike-Inspired Agent Architecture — structural patterns from NLE/BALROG/Arcgentica for Garden Salon
+- **sylveste-rsj.3.14** Run BALROG TextWorld baseline: raw model vs Skaffen-orchestrated progression comparison
+- **sylveste-rsj.3.5** Evaluate Agentica SDK as complementary agent framework — type-safe multi-agent with stateful REPL
+- **sylveste-rsj.8** Stigmergic coordination substrate — pheromone fields with decay on shared documents
+- **sylveste-s01c** Drop lattice->attp local-path replace (close iv-v5ayb residual)
+- **sylveste-s288** F4: install.sh — atomic, gated, transmissive close _(blocked)_
+- **sylveste-sn7** Tuivision: token-efficient terminal state encoding
+- **sylveste-sn7.10** Add ROI (region-of-interest) encoding — high fidelity for active regions only
+- **sylveste-sn7.14** Fix alternate screen buffer detection for cursor position
+- **Sylveste-so2i** intercore: ClearLocks staleness guard + --dry-run + classified tombstone event (f-060, f-192)
+- **sylveste-t5x4** auraken-thinker MCP server (sibling to auraken-lens) _(blocked)_
+- **sylveste-td2o** Brainstorm-summary feedforward into plan review (review <- plan,brainstorm)
+- **sylveste-tfj7** F7: Challenger slot mechanism for unqualified candidates _(blocked)_
+- **Sylveste-tfvr** bd cannot open the beads database in Nartopo and mediumsetting: pending schema migrations on dirty tables
+- **sylveste-ttlq** rig-autosync-freshness.py is tracked but declared in neither installer nor the health surface
+- **sylveste-ttwz** Triage Python MCP servers for Go port candidates (hot-path first) _(blocked)_
+- **sylveste-u28h** CPVO + DWSQ domain-general north star metrics (rsj.4 successor)
+- **sylveste-u74g** F7: build-dist.sh — deterministic bundle assembly _(blocked)_
+- **sylveste-uhjv** audit.log producer dormant — log-tool-invocation.sh not wired into settings.json
+- **sylveste-ukd3** lattice-web V0 — static browse + search at interverse/lattice/web/ _(blocked)_
+- **sylveste-ung7** Reconsider sylveste-7505 consolidation given spike C findings (cold-start math doesn't favor it) _(blocked)_
+- **sylveste-ungg** Local plan-phase check in /work + /execute-plan (intercore-independent)
+- **sylveste-usj** F5: Tier 1 INFORM signals + pleasure signals _(blocked)_
+- **sylveste-usvf** F5: Proactive model surfacing — SessionStart + weekly schedule _(blocked)_
+- **sylveste-uzpo** Interface evidence instrumentation — 5 cross-subsystem signals
+- **sylveste-v3ck** Demotion-rehearsal as M3+ promotion precondition
+- **sylveste-v4t2** Meadowsyn experiment suite (jpum successor)
+- **Sylveste-v7f** Add kimi as a flux-melange peer runtime (HTTP transport, no CLI) _(in progress)_
+- **sylveste-vsi4** F6: MCP server + Claude Code plugin _(blocked)_
+- **sylveste-w8zv** Rename github upstream mistakeknot/interweave → mistakeknot/lattice + update go.mod
+- **Sylveste-wch** Beads Session Close Protocol text is wrong: 'bd backup sync' does not flush Dolt→JSONL — protocol must use 'bd export > .beads/issues.jsonl'
+- **sylveste-wdf2** Doc monitoring automation (replaces interscout shape)
+- **sylveste-wdf2.2** L2: PreToolUse hook surfaces drift on doc access; auto-fire on Certain
+- **sylveste-wlk** Publish seed experiments after voice review
+- **Sylveste-wrz** Clavain: restore README count line + publish project-onboard update (0.6.252)
+- **Sylveste-ws38** auraken local history is unrelated to its remote — hook fix cannot be pushed
+- **Sylveste-x2c** Research spike: re-test 'MLX has no concurrent inference' premise (mlx-lm 0.18+) before sylveste-4wl burns on it
+- **sylveste-x6e4** Multi-mcpServers capability spike (prereq for sylveste-7505) _(deferred)_
+- **sylveste-xd0n** Forge mode on Signal transport
+- **sylveste-xfsr** F3: GitHub adapter — App webhooks, Issues, PRs, repo files _(blocked)_
+- **sylveste-xka6** Promote B2 complexity routing dispatch-side shadow -> enforce + quality-evidence _(blocked)_
+- **sylveste-xmav** F4: Notion adapter — pages, databases, webhooks (port from interkasten) _(blocked)_
+- **sylveste-xoki.1** Codex discovery hygiene: fix stale skill/frontmatter and cache noise
+- **sylveste-xoki.2** Agent evidence receipts for Codex and Claude Code
+- **sylveste-xoki.3** Plugin and skill architecture deprecation plan
+- **sylveste-xspv** Auto-revert timeout for pending forge code changes
+- **Sylveste-y6rl** Nothing stops a commit from adding a tracked dotfiles path with no declaration
+- **sylveste-ya2** F2: Auraken idea capture via /idea command _(blocked)_
+- **sylveste-ye7y** F4: Drift detection — sample-based + version-triggered _(blocked)_
+- **sylveste-yrc** clavain-cli not on PATH after monorepo clone
+- **sylveste-ysny** Skill calibration: signal density too low to trust scoring — gate autonomy on it
+- **sylveste-yxk8** F6: North Star integration + observation methodology + Goodhart breaker _(deferred)_
+- **sylveste-z55b** Refactor Clavain SessionStart into cached read model plus hook health ledger
 
-### Theme
-- **shadow-work-4wdr** Emergence & Integration — Feedback loops, cross-system testing, validation
-- **shadow-work-93mh** Renderer & Graphics — Bevy renderer, MetalFX upscaling, visual polish
-- **shadow-work-jol0** Gameplay & UX — UI polish, interaction design, and player experience
-- **shadow-work-jxnz** Agent Sim Fidelity — Personality, memory, ideology, actions, recruitment
-- **shadow-work-whlc** Content & Scenarios — Authored gameplay content from ARCHITECTURE specs
+### upstream-sync
+- **Sylveste-ie6.11** sp-lab: tombstone dead slack-messaging skill + vendor new windows-vm skill
+
+### v6-candidate
+- **sylveste-2h3o** Phase 3-4 bootstrap spec — initial governance policy + handoff criteria
+- **sylveste-9um7** Routing-decision evidence schema for Ockham + Clavain + intercept
+- **sylveste-aon0** Cross-source evidence independence test
+- **sylveste-xq0t** Per-tier demotion latency bounds
 
 ---
 
 ## P3 - Later
 
-### Post-v1
-- **shadow-work-3ni** Historical replay — golden seed
-- **shadow-work-872** Web distribution — WASM binary size optimization (Phase 3)
-- **shadow-work-bi5** Secondary focal countries
-- **shadow-work-hm3** Cross-platform packaging
+### auraken
+- **sylveste-2l1.7** Arctic Shift extraction for niche subreddits
+- **Sylveste-8p3** AURAKEN_BOOTSTRAP=off builder bypass for onboarding arc
+
+### clavain
+- **sylveste-kogm** /context-restore + structured WIP-commit metadata (parked)
+- **Sylveste-u59** Config adoption pass: fallbackModel chain, Tool(param:value) permission rules, sandbox.credentials/deniedDomains
+
+### interfer
+- **sylveste-7hxm** Route-heuristic-coverage interlab campaign
+- **Sylveste-uk3** OpenRouter stream usage block omits reasoning_tokens — gen_tps/cost telemetry undercounts on bvh
+
+### interfere
+- **sylveste-1zh** Experiment: StreamingLLM attention sinks for infinite context
+- **sylveste-308** Autoresearch: SSD page cache pre-fetching for 397B streaming _(blocked)_
+- **sylveste-37g** Experiment: Mixture of Depths (MoD) dynamic layer routing
+- **sylveste-3uy** Autoresearch: Metal compute shader optimization _(blocked)_
+- **sylveste-4wl** Autoresearch: adaptive batching parameters for concurrent agents _(blocked)_
+- **sylveste-8v3** Benchmark Kimi K2.5 3-bit (1T, 32B active) _(blocked)_
+- **sylveste-9tc** Autoresearch: LayerSkip exit threshold tuning _(blocked)_
+- **sylveste-bpg** Benchmark GLM-5 4-bit (744B, 40B active) _(blocked)_
+- **sylveste-f0k** Experiment: reservoir computing readout for task routing
+- **sylveste-i8u** Experiment: custom Metal compute shaders for mlx-lm
+- **sylveste-ji6** Experiment: Multi-head Latent Attention (MLA) for KV compression _(deferred)_
+- **sylveste-naj** BHQ speed optimization via autoresearch _(deferred)_
+- **sylveste-uln** Benchmark DeepSeek V3.2 4-bit (672B, ~37B active) _(blocked)_
+- **sylveste-xc8** Experiment: memory wiring and page cache optimization for SSD streaming _(blocked)_
+
+### interflux
+- **sylveste-9lp.25** P3: Learned orchestration from run history — requires labeled negative data
+- **sylveste-9lp.26** P3: Query decomposition for complex research — confirmed v2, focus on exploratory+onboarding types
+- **sylveste-9lp.27** P3: Domain-specific research agents — flux-gen equivalent for research side
+- **sylveste-9lp.28** P3: Per-finding sycophancy detection — architecture ready in reaction.yaml, deferred until fleet grows
+- **sylveste-9lp.29** P3: Triage subagent — offload Steps 1.0-1.2 from host context
+- **sylveste-9lp.32.6.10** BP-C1.B.drift: migrate fluxbench-drift.sh registry writes (needs flock restructure)
+- **sylveste-9lp.32.6.11** BP-C1.B.discover: migrate discover-merge.sh registry writes (needs add-model primitive)
+- **sylveste-fyo3.10** P3: Weekly discovery agent automation — run fluxbench-discover.md on cron schedule _(blocked)_
+- **sylveste-fyo3.11** P3: Oracle cross-AI review integration — enable non-Claude peer review via Oracle binary
+- **sylveste-fyo3.7** P2: Interspect overlay activation — promote from progressive enhancement to default
+
+### interproof
+- **sylveste-ayl** Manual-driven feature validation plugin
+
+### interspect
+- **sylveste-sfhq.4** Tool-remediation canary + revert plumbing (sfhq.3 follow-up)
+- **Sylveste-uiw** Ingest OTEL workflow.run_id + agent_id/parent_agent_id span attribution as routing evidence
+
+### interstat
+- **Sylveste-xvt** Investigate hash-ID fallback: 70% of subagent rows have unparseable agent_name
+
+### routing
+- **Sylveste-23w** Propagate verify_frontmatter.py + routing-drift workflow to sibling subrepos
+- **Sylveste-7zi** Investigate fd-architecture/fd-systems opus-vs-sonnet disagreement
+
+### scoping
+- **Sylveste-s10** Small-local-model (sub-10B) workload candidates after microrouter cluster close
 
 ### sylveste
-- **Revel-gn9** Cuisine quality system
-- **Revel-p6m** Full art data files — 36 base types, 40+ prefixes, 50+ suffixes
-- **Revel-xhd** Harden Claude review schema compliance for large evidence packages _(in progress)_
-- **shadow-work-6m3** Research: worldmonitor (GitHub) — real-time global monitoring reference
-- **shadow-work-6mc** TUI: Active deployments panel
-- **shadow-work-75ca** Posture formula separation — Thoroughness/Diligence and Improvisation/Creativity collapse
-- **shadow-work-7hli** TUI: Finance and political capital detail view
-- **shadow-work-7zi** Research: Situational Unawareness (The Baffler) — intelligence dashboard critique
-- **shadow-work-9l5j** TUI: F-key panel switching (Bloomberg function keys)
-- **shadow-work-alej** TUI: Command bar (Bloomberg-style)
-- **shadow-work-bhca** Missing cross-category interaction pairs
-- **shadow-work-fjo9** Scenario: Author 2-3 additional scenario seed configs
-- **shadow-work-i3s** TUI: Active issues panel
-- **shadow-work-mi3** TUI: Pressure matrix heatmap
-- **shadow-work-ohhv** Base simulation wire: Optimism → perceived-risk bias
-- **shadow-work-rqfo** TUI: Interactive recruit and deploy
-- **shadow-work-t84f.2** Break up oversized mixed-responsibility modules uncovered by perf review
-- **shadow-work-u53r** Base simulation wire: Diligence → success-rate modifier
-- **shadow-work-vrt6** Posture formula separation: Thoroughness/Diligence and Improvisation/Creativity
-- **shadow-work-yaxt** AngerThreshold recovery mechanic — Solo recovery evolution event
+- **Sylveste-05t** Research spike: self-speculative decoding via native MTP heads on downloaded MoE checkpoints
+- **Sylveste-0fd** interchart: regenerate-and-deploy.sh doesn't deploy — only pushes to GitHub
+- **Sylveste-0ww** Research spike: null-test graph/lens retrieval vs naive baseline on real Auraken/lattice queries
+- **sylveste-1h0b** Build Komoroske profile via proven pipeline (return from deferral) _(blocked)_
+- **sylveste-22oi.6** Reconcile stale non-dist SKILL.md duplicate in Auraken Hermes tree
+- **Sylveste-31v** Run install-macos.sh on Mac to restore claude-plugin-cleanup.sh + LaunchAgent _(blocked)_
+- **sylveste-3rod** Sylveste Mythos launch readiness — 3-month focus + launch-on-drop trigger _(blocked)_
+- **sylveste-3xl3.5** Audit fd-* and researcher agent definitions for teammate-role reuse
+- **sylveste-3xl3.6** Plan-approval teammate mode → quality-gates / authz framework integration
+- **sylveste-3xl3.8** flux-explore --teams Approach 3: full team-driven exploration _(blocked)_
+- **Sylveste-46v** Clavain: clean stale publish_state rows + audit cross-marketplace drift
+- **Sylveste-4b5.17** Rimsky (3kol) topology doc-hygiene: record flat-fan-out structural rule
+- **Sylveste-4b5.18** Cache-aware effective-cost term in B2 routing (child of xka6, gated on enforce) _(blocked)_
+- **Sylveste-4b5.19** Contamination-resistant benchmark re-pin (deferred, gated on harness consuming a routing decision)
+- **Sylveste-4b5.20** VerifyLoop feasibility — self-generated-oracle iteration vs TDD baseline (research spike) _(blocked)_
+- **Sylveste-4b5.21** interrank benchmark source-provenance ranking input (child of s3z6, gated on s10) _(blocked)_
+- **Sylveste-4b5.22** Local lint-triage classifier feasibility (s10 child, measure-only, likely-moot)
+- **Sylveste-4b5.23** CoAgent live-external-state concurrency watch-item (gated, self-limiting, kill-dated)
+- **Sylveste-4b8** Research spike: LLM-judge reliability harness for interflux + cross-model consensus test
+- **sylveste-4epi** Interlab observability audit — masaq METRIC wrappers (dxzr successor)
+- **sylveste-52ys** Rao profile (self-referential essay-chain test) _(blocked)_
+- **sylveste-55hj** Agent fitness decay (finding->commit integration rate)
+- **sylveste-5va** Auto-generate graph edges from content themes + lineage fields
+- **sylveste-6zy** xterm.js slide-out panel component for project pages
+- **sylveste-7aj8.6** interspect skillcal: tune-overlays — skill_tune action + overlay format _(blocked)_
+- **sylveste-7aj8.7** interspect skillcal: canary + autonomy — regression trigger + safe-list _(blocked)_
+- **Sylveste-8ew7** Generators run on --help instead of printing usage
+- **sylveste-8g69** Thompson profile or substitute (analytical-framework consistency test) _(blocked)_
+- **sylveste-8qk** F8: Philosophy amendment + documentation
+- **Sylveste-8rpw** zklw: delete the phantom ~/projects/Demarch tree (needs mk's go)
+- **Sylveste-942** Fix /Users/arouth hardcoded path in com.arouth.claude-plugin-cleanup.plist
+- **sylveste-9prl** Wei profile (rare-frame detection test) _(blocked)_
+- **sylveste-9xyh** beads: bd dolt status errors with 'not supported in embedded mode' but bd dolt help lists it unconditionally under Server lifecycle
+- **sylveste-a4oj.10** Phase 3 — Infrastructure-class improvements (M+ difficulty bundle)
+- **sylveste-a4oj.12** Memory depth-tiered archiving: project_status frontmatter + close-off depth automation
+- **sylveste-a4oj.14** M-01 follow-up: per-project user-scope MCP server suppression (mcpProfile-equivalent)
+- **sylveste-a4oj.9.3.1** Semantic-embedding dup detection (extends 9.3 lexical baseline)
+- **sylveste-amcz** F2: interserve-py adapter framework _(blocked)_
+- **Sylveste-aso** Umbrella gitignore: docs/research/*/ rule is leaky for nested content
+- **Sylveste-bgj** Unify docs/prd/ and docs/prds/ directory structure
+- **sylveste-c231** Add quarantined-worktree disposal runbook to Sylveste docs (generic version of elf-revel solutions doc)
+- **sylveste-dxt7** intercore gate-rule registry (OS-layer extensibility)
+- **sylveste-e20** /intersite:publish with atomic swap deploy
+- **Sylveste-e7m3** sylveste-vision.md links to docs/sylveste-reference.md, which does not exist
+- **sylveste-esjb** Bootstrap or retire the 16 beads DBs with no local database
+- **sylveste-fba8** Hardware-aware model recommendations in interrank (1ifn successor)
+- **sylveste-fdn** 301 redirect: blog.generalsystemsventures.com to /blog/
+- **sylveste-fj1w** Clavain peer-coexistence B′ — peer-aware using-clavain + peers.yaml registry (gated on telemetry)
+- **sylveste-gaid** Auraken: SKILL.md cross-model voice portability — potential research finding
+- **sylveste-gw6** WebSocket PTY relay service at apps/intersite-relay/
+- **sylveste-h4mw** F1: interserve plugin scaffold _(blocked)_
+- **sylveste-hfmh** Retire interscout plugin (deprecated 2026-04-27)
+- **sylveste-hvmc** intermute live transport v1.5: active-probe readiness check (replaces 2s staleness)
+- **Sylveste-i3h** Research spike: expert-activation traces → Belady-approximating cache policy for flash-moe
+- **sylveste-jciw** clavain-cli sprint-init gate diverges from bd doctor (false-positive '1 error(s)')
+- **sylveste-jp1l** interjawn MCP server fails to start — Prisma ESM export error
+- **sylveste-jsyc** F6: Big-bang cutover — remove legacy mcpServers entries _(blocked)_
+- **sylveste-lbkd** Sprint v2 artifact bus + progress trackers (lta9 successor)
+- **sylveste-lgci** A:L4 — evaluate skill-selection calibration as a 4th autonomy loop (post-v0.7)
+- **sylveste-liiu** Per-hook preamble byte telemetry for automatic regression detection
+- **sylveste-lpnd** ATTP attestation protocol for interweave (e1mi successor)
+- **Sylveste-lsh8** Post the drafted bd export -o upstream report to gastownhall/beads
+- **Sylveste-m3wd** interlore is on master, not main, against the estate convention
+- **sylveste-m5g** intersite-relay: xterm.js dev panel + WebSocket PTY relay
+- **sylveste-nr6x.12** Infra: install signal-cli + register hassease Signal account
+- **Sylveste-ns0m** dotfiles .claude/CLAUDE.md — last file of the retired root tree, carved out for a sibling session
+- **sylveste-nxfq** sprint: automated import-graph assertion from plan's structural requirements
+- **Sylveste-omz** Research spike: temporal fact-invalidation (t_valid/t_invalid) for intermem
+- **sylveste-ovux** Upstream Hermes skill frontmatter aliases (support /ak for /auraken natively)
+- **sylveste-oyrf** Longitudinal cost-calibration + Mythos launch artifacts
+- **sylveste-oyrf.3** 90s self-building asciicast per fd-demo-artifact-authenticity shot list
+- **Sylveste-oz7o** interchart artefact still machine-dependent after the case fix
+- **sylveste-p2yj** Go benchmark-driven optimization for Skaffen hot paths (0pvp successor)
+- **Sylveste-r5t** Clavain: investigate skill-precedence — ~/.claude/skills/ override didn't beat cached plugin SKILL.md
+- **sylveste-rm8w** lattice: function diagnostic property mismatch (families.py vs diagnostics.py)
+- **sylveste-rsj.3.4** Permaconsequence visibility: make cross-session evidence compounding visible in Garden Salon UX
+- **sylveste-rsj.3.6** GameDevBench integration: add game-building benchmark alongside SWE-bench for complex multi-file evaluation
+- **Sylveste-ry3** Research spike: orchestrator-visibility safety audit (hidden dispatch vs dissent suppression)
+- **sylveste-sn7.11** Separate UI chrome (borders, status lines) from content in output
+- **sylveste-sn7.12** Add channel-selective encoding — callers choose which attributes to include
+- **sylveste-sn7.13** Add session-local dictionary for repeated content patterns
+- **sylveste-sn7.15** Add generative encoding for structured UI — template+data instead of full render
+- **sylveste-sn7.16** Add information hierarchy (L0/L1/L2/L3) to all output modes
+- **sylveste-sn7.17** Add multi-pane marshalling — named pane composition for tmux/splits
+- **sylveste-sn7.18** Add task-adapted rendering profiles (interactive/content/structure)
+- **sylveste-sn7.19** Add agent backchanneling — LLM negotiates detail level
+- **sylveste-sn7.20** Add color semantics lookup table for common terminal applications
+- **sylveste-sn7.21** Explore occlusion culling — skip background content behind modal dialogs
+- **sylveste-sn7.22** Document vision token cache disadvantage for multi-turn agent sessions
+- **sylveste-sn7.6** Add motif/summary LOD level (L0) for polling tasks
+- **sylveste-sn7.7** SVG CSS class dictionary — deduplicate repeated class/color attributes
+- **sylveste-sn7.8** Add diff/delta mode with auto-refresh every 5 turns
+- **sylveste-sn7.9** Add semantic role annotations (ARIA-like) for terminal elements
+- **Sylveste-sox** xp7-c: investigate why Claude Code plugin auto-loader silently drops interlock hooks
+- **Sylveste-tpc** Research spike: lens authoring-drift pairs (sylveste-05rf) as semantic versioning
+- **sylveste-tsvw** intercore coordination quota/fairness (pre-scale insurance)
+- **sylveste-u6fj** F7: interkasten migration + archival _(blocked)_
+- **Sylveste-va4** Research spike: M5 Neural Accelerator prefill/decode asymmetry measurement
+- **sylveste-w4sj** v1.0 roadmap artifact publishing (enxv successor)
+- **sylveste-wdf2.3** L3+L4: /schedule routines for floor refresh and monthly audit
+- **sylveste-y6m7** Audit + clean parent-epic depends_on edges in b1ha (and other epics)
+- **sylveste-z0pc** Skill-description boilerplate standardization via interskill:audit
+- **sylveste-z1sq** interline statusline: scope next_bead to session lane (tmux name)
 
-### Theme
-- **shadow-work-2q9g** Tooling & Infrastructure — Dev tools, CI, campaign runner, diagnostics
-- **shadow-work-c937** Technical Debt & Performance — Refactoring, tick perf, simplification
+### upstream-sync
+- **Sylveste-ie6.4** compound-refresh: staleness audit for docs/solutions KB
+- **Sylveste-ie6.5** ce-ideate-style pre-brainstorm idea generation+critique stage
+- **Sylveste-ie6.6** product-pulse: read-side user-outcome telemetry loop
 
 ---
 
 ## P4 - Someday
 
+### interfere
+- **sylveste-0zc** Experiment: ANE (Apple Neural Engine) offload for attention _(deferred)_
+- **sylveste-c57** Experiment: ant colony optimization for expert routing paths _(deferred)_
+- **sylveste-eka** Experiment: thermodynamic-inspired annealing for expert selection _(deferred)_
+
+### observability
+- **Sylveste-9ve** Explore subagent dispatches stopped 2026-04-21 — verify whether workflow shift or instrumentation gap
+
+### routing
+- **Sylveste-10p** Add pre-commit hook layer for frontmatter drift (light gate)
+- **Sylveste-vft** Drift baseline ratcheting — committed .routing-drift-baseline file
+
 ### sylveste
-- **shadow-work-byob** TUI: SW_API_KEY auth support
-- **shadow-work-j29** Individual character simulation (Layer 1)
-- **shadow-work-nen** Modding and scenario editor
-- **shadow-work-wbd** Multiplayer — shared worlds
+- **sylveste-wdf2.4** L5 (deferred): Substrate-independent external replay
+- **sylveste-yofd** Clavain peer-coexistence C′ — full rig manager (profiles, lockfile, per-skill priorities, rig CLI)
+- **sylveste-zfsj** intermute live transport v2: cross-host (SSH + tmux orchestration)

--- a/docs/roadmap.json
+++ b/docs/roadmap.json
@@ -1,19 +1,154 @@
 {
-  "project": "demarch",
-  "kind": "demarch-monorepo-roadmap",
-  "generated_at": "2026-07-13T15:40:45Z",
-  "module_count": 85,
-  "open_beads": 62,
-  "blocked": 1,
+  "project": "sylveste",
+  "kind": "sylveste-monorepo-roadmap",
+  "generated_at": "2026-08-08T01:59:19Z",
+  "module_count": 137,
+  "open_beads": 481,
+  "blocked": 128,
   "modules": [
     {
-      "module": ".clavain",
-      "location": "interverse/.clavain",
+      "module": "auraken",
+      "location": "apps/auraken",
+      "version": "0.1.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "Autarch",
+      "location": "apps/Autarch",
+      "version": "0.1.0",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
+    },
+    {
+      "module": "interblog",
+      "location": "apps/interblog",
+      "version": "0.1.4",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "Intercom",
+      "location": "apps/Intercom",
+      "version": "1.1.0",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
+    },
+    {
+      "module": "intersite",
+      "location": "apps/intersite",
       "version": "—",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
       "status": "planned"
+    },
+    {
+      "module": "Khouri",
+      "location": "apps/Khouri",
+      "version": "0.1.0",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
+    },
+    {
+      "module": "latro",
+      "location": "apps/latro",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "Meadowsyn",
+      "location": "apps/Meadowsyn",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "agent-rig",
+      "location": "core/agent-rig",
+      "version": "0.1.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "interband",
+      "location": "core/interband",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "interbench",
+      "location": "core/interbench",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "intercore",
+      "location": "core/intercore",
+      "version": "—",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
+    },
+    {
+      "module": "intermute",
+      "location": "core/intermute",
+      "version": "—",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
+    },
+    {
+      "module": "interweave",
+      "location": "core/interweave",
+      "version": "0.2.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "marketplace",
+      "location": "core/marketplace",
+      "version": "—",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
+    },
+    {
+      "module": "marketplace.broken",
+      "location": "core/marketplace.broken",
+      "version": "—",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
     },
     {
       "module": "_shared",
@@ -25,9 +160,36 @@
       "status": "planned"
     },
     {
+      "module": ".audit-2026-06-23",
+      "location": "interverse/.audit-2026-06-23",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "cujgel",
+      "location": "interverse/cujgel",
+      "version": "0.2.1",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "interboxd",
+      "location": "interverse/interboxd",
+      "version": "0.1.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
       "module": "interbrowse",
       "location": "interverse/interbrowse",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -45,7 +207,7 @@
     {
       "module": "intercept",
       "location": "interverse/intercept",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -54,7 +216,7 @@
     {
       "module": "interchart",
       "location": "interverse/interchart",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -63,7 +225,7 @@
     {
       "module": "intercheck",
       "location": "interverse/intercheck",
-      "version": "0.2.2",
+      "version": "0.2.4",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -77,6 +239,15 @@
       "roadmap_source": "beads",
       "open_beads": 0,
       "status": "active"
+    },
+    {
+      "module": "intercut",
+      "location": "interverse/intercut",
+      "version": "0.1.1",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
     },
     {
       "module": "interdeep",
@@ -126,7 +297,7 @@
     {
       "module": "interfluence",
       "location": "interverse/interfluence",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -135,7 +306,7 @@
     {
       "module": "interflux",
       "location": "interverse/interflux",
-      "version": "0.2.74",
+      "version": "0.2.86",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -151,9 +322,18 @@
       "status": "active"
     },
     {
+      "module": "intergraph",
+      "location": "interverse/intergraph",
+      "version": "0.1.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
       "module": "interhelm",
       "location": "interverse/interhelm",
-      "version": "0.2.2",
+      "version": "0.2.4",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -162,7 +342,7 @@
     {
       "module": "interject",
       "location": "interverse/interject",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -171,7 +351,7 @@
     {
       "module": "interkasten",
       "location": "interverse/interkasten",
-      "version": "0.4.25",
+      "version": "0.4.26",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -180,7 +360,7 @@
     {
       "module": "interknow",
       "location": "interverse/interknow",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -189,7 +369,7 @@
     {
       "module": "interlab",
       "location": "interverse/interlab",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -198,7 +378,7 @@
     {
       "module": "interlearn",
       "location": "interverse/interlearn",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -225,7 +405,7 @@
     {
       "module": "interline",
       "location": "interverse/interline",
-      "version": "0.2.15",
+      "version": "0.2.18",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -234,16 +414,25 @@
     {
       "module": "interlock",
       "location": "interverse/interlock",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
       "status": "active"
     },
     {
+      "module": "interloop",
+      "location": "interverse/interloop",
+      "version": "0.1.1",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
       "module": "interlore",
       "location": "interverse/interlore",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -261,7 +450,7 @@
     {
       "module": "intermem",
       "location": "interverse/intermem",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -288,7 +477,7 @@
     {
       "module": "intermux",
       "location": "interverse/intermux",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -313,18 +502,9 @@
       "status": "active"
     },
     {
-      "module": "interop",
-      "location": "interverse/interop",
-      "version": "—",
-      "has_roadmap": false,
-      "roadmap_source": "none",
-      "open_beads": 0,
-      "status": "planned"
-    },
-    {
       "module": "interpath",
       "location": "interverse/interpath",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -342,7 +522,7 @@
     {
       "module": "interphase",
       "location": "interverse/interphase",
-      "version": "0.3.17",
+      "version": "0.3.20",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -360,7 +540,7 @@
     {
       "module": "interpub",
       "location": "interverse/interpub",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -369,7 +549,7 @@
     {
       "module": "interpulse",
       "location": "interverse/interpulse",
-      "version": "0.1.5",
+      "version": "0.1.10",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -378,7 +558,7 @@
     {
       "module": "interrank",
       "location": "interverse/interrank",
-      "version": "0.3.1",
+      "version": "0.3.4",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -405,7 +585,7 @@
     {
       "module": "intersearch",
       "location": "interverse/intersearch",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -432,7 +612,7 @@
     {
       "module": "intership",
       "location": "interverse/intership",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -477,7 +657,7 @@
     {
       "module": "interspect",
       "location": "interverse/interspect",
-      "version": "0.1.22",
+      "version": "0.1.25",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -486,16 +666,25 @@
     {
       "module": "interstat",
       "location": "interverse/interstat",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
       "status": "active"
     },
     {
+      "module": "interstate",
+      "location": "interverse/interstate",
+      "version": "0.5.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
       "module": "intersynth",
       "location": "interverse/intersynth",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -522,7 +711,7 @@
     {
       "module": "intertrack",
       "location": "interverse/intertrack",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -547,9 +736,27 @@
       "status": "early"
     },
     {
+      "module": "intervoice",
+      "location": "interverse/intervoice",
+      "version": "0.1.1",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "intervox",
+      "location": "interverse/intervox",
+      "version": "0.2.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
       "module": "interwatch",
       "location": "interverse/interwatch",
-      "version": "0.5.0",
+      "version": "0.6.1",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -567,7 +774,7 @@
     {
       "module": "tldr-swinton",
       "location": "interverse/tldr-swinton",
-      "version": "0.7.19",
+      "version": "0.8.4",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -576,7 +783,7 @@
     {
       "module": "tool-time",
       "location": "interverse/tool-time",
-      "version": "0.4.0",
+      "version": "0.4.3",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -599,6 +806,24 @@
       "roadmap_source": "none",
       "open_beads": 0,
       "status": "planned"
+    },
+    {
+      "module": "Clavain",
+      "location": "os/Clavain",
+      "version": "0.6.293",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
+    },
+    {
+      "module": "Clavain-pub",
+      "location": "os/Clavain-pub",
+      "version": "0.6.294",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
     },
     {
       "module": "Ockham",
@@ -637,44 +862,17 @@
       "status": "planned"
     },
     {
-      "module": "Auraken",
-      "location": "apps/Auraken",
-      "version": "0.1.0",
+      "module": "agentic_coding_flywheel_setup",
+      "location": "research/agentic_coding_flywheel_setup",
+      "version": "0.7.0",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
       "status": "early"
     },
     {
-      "module": "Autarch",
-      "location": "apps/Autarch",
-      "version": "0.1.0",
-      "has_roadmap": true,
-      "roadmap_source": "beads",
-      "open_beads": 0,
-      "status": "active"
-    },
-    {
-      "module": "Intercom",
-      "location": "apps/Intercom",
-      "version": "1.1.0",
-      "has_roadmap": true,
-      "roadmap_source": "beads",
-      "open_beads": 0,
-      "status": "active"
-    },
-    {
-      "module": "Khouri",
-      "location": "apps/Khouri",
-      "version": "0.1.0",
-      "has_roadmap": true,
-      "roadmap_source": "beads",
-      "open_beads": 0,
-      "status": "active"
-    },
-    {
-      "module": "Meadowsyn",
-      "location": "apps/Meadowsyn",
+      "module": "agi-hyperspace",
+      "location": "research/agi-hyperspace",
       "version": "—",
       "has_roadmap": false,
       "roadmap_source": "none",
@@ -682,35 +880,8 @@
       "status": "planned"
     },
     {
-      "module": "interblog",
-      "location": "apps/interblog",
-      "version": "0.1.4",
-      "has_roadmap": false,
-      "roadmap_source": "none",
-      "open_beads": 0,
-      "status": "early"
-    },
-    {
-      "module": "intersite",
-      "location": "apps/intersite",
-      "version": "0.1.0",
-      "has_roadmap": false,
-      "roadmap_source": "none",
-      "open_beads": 0,
-      "status": "early"
-    },
-    {
-      "module": "agent-rig",
-      "location": "core/agent-rig",
-      "version": "0.1.0",
-      "has_roadmap": false,
-      "roadmap_source": "none",
-      "open_beads": 0,
-      "status": "early"
-    },
-    {
-      "module": "interband",
-      "location": "core/interband",
+      "module": "automated_plan_reviser_pro",
+      "location": "research/automated_plan_reviser_pro",
       "version": "—",
       "has_roadmap": false,
       "roadmap_source": "none",
@@ -718,8 +889,8 @@
       "status": "planned"
     },
     {
-      "module": "interbench",
-      "location": "core/interbench",
+      "module": "beads_for_cass",
+      "location": "research/beads_for_cass",
       "version": "—",
       "has_roadmap": false,
       "roadmap_source": "none",
@@ -727,31 +898,328 @@
       "status": "planned"
     },
     {
-      "module": "intercore",
-      "location": "core/intercore",
+      "module": "beads_rust",
+      "location": "research/beads_rust",
       "version": "—",
-      "has_roadmap": true,
-      "roadmap_source": "beads",
+      "has_roadmap": false,
+      "roadmap_source": "none",
       "open_beads": 0,
-      "status": "active"
+      "status": "planned"
     },
     {
-      "module": "intermute",
-      "location": "core/intermute",
+      "module": "beads_viewer",
+      "location": "research/beads_viewer",
       "version": "—",
-      "has_roadmap": true,
-      "roadmap_source": "beads",
+      "has_roadmap": false,
+      "roadmap_source": "none",
       "open_beads": 0,
-      "status": "active"
+      "status": "planned"
     },
     {
-      "module": "marketplace",
-      "location": "core/marketplace",
+      "module": "beads_viewer_for_agentic_coding_flywheel_setup",
+      "location": "research/beads_viewer_for_agentic_coding_flywheel_setup",
       "version": "—",
-      "has_roadmap": true,
-      "roadmap_source": "beads",
+      "has_roadmap": false,
+      "roadmap_source": "none",
       "open_beads": 0,
-      "status": "active"
+      "status": "planned"
+    },
+    {
+      "module": "beads_viewer-pages",
+      "location": "research/beads_viewer-pages",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "cass_memory_system",
+      "location": "research/cass_memory_system",
+      "version": "0.2.3",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "claude_code_agent_farm",
+      "location": "research/claude_code_agent_farm",
+      "version": "1.0.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "coding_agent_session_search",
+      "location": "research/coding_agent_session_search",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "cross_agent_session_resumer",
+      "location": "research/cross_agent_session_resumer",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "destructive_command_guard",
+      "location": "research/destructive_command_guard",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "fastmcp_rust",
+      "location": "research/fastmcp_rust",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "flywheel_gateway",
+      "location": "research/flywheel_gateway",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "franken_agent_detection",
+      "location": "research/franken_agent_detection",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "frankensearch",
+      "location": "research/frankensearch",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "frankentui",
+      "location": "research/frankentui",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "gastown",
+      "location": "research/gastown",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "gemini-api-updater-doc",
+      "location": "research/gemini-api-updater-doc",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "get-shit-done",
+      "location": "research/get-shit-done",
+      "version": "1.29.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "goosetown",
+      "location": "research/goosetown",
+      "version": "0.1.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "gpt-researcher",
+      "location": "research/gpt-researcher",
+      "version": "0.14.7",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "gsv-portfolio-39",
+      "location": "research/gsv-portfolio-39",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "guide_to_openai_response_api_and_agents_sdk",
+      "location": "research/guide_to_openai_response_api_and_agents_sdk",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "hermes_agent",
+      "location": "research/hermes_agent",
+      "version": "1.0.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "jido",
+      "location": "research/jido",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "llm_docs",
+      "location": "research/llm_docs",
+      "version": "0.1.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "llm_multi_round_coding_tournament",
+      "location": "research/llm_multi_round_coding_tournament",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "mcp_agent_mail",
+      "location": "research/mcp_agent_mail",
+      "version": "0.3.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "mcp_agent_mail_rust",
+      "location": "research/mcp_agent_mail_rust",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "meta_skill",
+      "location": "research/meta_skill",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "ntm",
+      "location": "research/ntm",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "pi_agent_rust",
+      "location": "research/pi_agent_rust",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "pi-autoresearch",
+      "location": "research/pi-autoresearch",
+      "version": "1.0.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "pi-mono",
+      "location": "research/pi-mono",
+      "version": "0.0.3",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "post_compact_reminder",
+      "location": "research/post_compact_reminder",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "slb",
+      "location": "research/slb",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "ultimate_bug_scanner",
+      "location": "research/ultimate_bug_scanner",
+      "version": "0.0.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "your-source-to-prompt.html",
+      "location": "research/your-source-to-prompt.html",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
     },
     {
       "module": "interbase",
@@ -763,7 +1231,7 @@
       "status": "active"
     },
     {
-      "module": "demarch",
+      "module": "sylveste",
       "location": "root",
       "version": "—",
       "has_roadmap": true,
@@ -774,13 +1242,148 @@
   ],
   "snapshot": [
     {
-      "module": ".clavain",
-      "location": "interverse/.clavain",
+      "module": "auraken",
+      "location": "apps/auraken",
+      "version": "0.1.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "Autarch",
+      "location": "apps/Autarch",
+      "version": "0.1.0",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
+    },
+    {
+      "module": "interblog",
+      "location": "apps/interblog",
+      "version": "0.1.4",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "Intercom",
+      "location": "apps/Intercom",
+      "version": "1.1.0",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
+    },
+    {
+      "module": "intersite",
+      "location": "apps/intersite",
       "version": "—",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
       "status": "planned"
+    },
+    {
+      "module": "Khouri",
+      "location": "apps/Khouri",
+      "version": "0.1.0",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
+    },
+    {
+      "module": "latro",
+      "location": "apps/latro",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "Meadowsyn",
+      "location": "apps/Meadowsyn",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "agent-rig",
+      "location": "core/agent-rig",
+      "version": "0.1.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "interband",
+      "location": "core/interband",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "interbench",
+      "location": "core/interbench",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "intercore",
+      "location": "core/intercore",
+      "version": "—",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
+    },
+    {
+      "module": "intermute",
+      "location": "core/intermute",
+      "version": "—",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
+    },
+    {
+      "module": "interweave",
+      "location": "core/interweave",
+      "version": "0.2.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "marketplace",
+      "location": "core/marketplace",
+      "version": "—",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
+    },
+    {
+      "module": "marketplace.broken",
+      "location": "core/marketplace.broken",
+      "version": "—",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
     },
     {
       "module": "_shared",
@@ -792,9 +1395,36 @@
       "status": "planned"
     },
     {
+      "module": ".audit-2026-06-23",
+      "location": "interverse/.audit-2026-06-23",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "cujgel",
+      "location": "interverse/cujgel",
+      "version": "0.2.1",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "interboxd",
+      "location": "interverse/interboxd",
+      "version": "0.1.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
       "module": "interbrowse",
       "location": "interverse/interbrowse",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -812,7 +1442,7 @@
     {
       "module": "intercept",
       "location": "interverse/intercept",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -821,7 +1451,7 @@
     {
       "module": "interchart",
       "location": "interverse/interchart",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -830,7 +1460,7 @@
     {
       "module": "intercheck",
       "location": "interverse/intercheck",
-      "version": "0.2.2",
+      "version": "0.2.4",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -844,6 +1474,15 @@
       "roadmap_source": "beads",
       "open_beads": 0,
       "status": "active"
+    },
+    {
+      "module": "intercut",
+      "location": "interverse/intercut",
+      "version": "0.1.1",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
     },
     {
       "module": "interdeep",
@@ -893,7 +1532,7 @@
     {
       "module": "interfluence",
       "location": "interverse/interfluence",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -902,7 +1541,7 @@
     {
       "module": "interflux",
       "location": "interverse/interflux",
-      "version": "0.2.74",
+      "version": "0.2.86",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -918,9 +1557,18 @@
       "status": "active"
     },
     {
+      "module": "intergraph",
+      "location": "interverse/intergraph",
+      "version": "0.1.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
       "module": "interhelm",
       "location": "interverse/interhelm",
-      "version": "0.2.2",
+      "version": "0.2.4",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -929,7 +1577,7 @@
     {
       "module": "interject",
       "location": "interverse/interject",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -938,7 +1586,7 @@
     {
       "module": "interkasten",
       "location": "interverse/interkasten",
-      "version": "0.4.25",
+      "version": "0.4.26",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -947,7 +1595,7 @@
     {
       "module": "interknow",
       "location": "interverse/interknow",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -956,7 +1604,7 @@
     {
       "module": "interlab",
       "location": "interverse/interlab",
-      "version": "0.4.8",
+      "version": "0.4.9",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -965,7 +1613,7 @@
     {
       "module": "interlearn",
       "location": "interverse/interlearn",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -992,7 +1640,7 @@
     {
       "module": "interline",
       "location": "interverse/interline",
-      "version": "0.2.15",
+      "version": "0.2.18",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -1001,16 +1649,25 @@
     {
       "module": "interlock",
       "location": "interverse/interlock",
-      "version": "0.2.17",
+      "version": "0.2.18",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
       "status": "active"
     },
     {
+      "module": "interloop",
+      "location": "interverse/interloop",
+      "version": "0.1.1",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
       "module": "interlore",
       "location": "interverse/interlore",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -1028,7 +1685,7 @@
     {
       "module": "intermem",
       "location": "interverse/intermem",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -1055,7 +1712,7 @@
     {
       "module": "intermux",
       "location": "interverse/intermux",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -1080,18 +1737,9 @@
       "status": "active"
     },
     {
-      "module": "interop",
-      "location": "interverse/interop",
-      "version": "—",
-      "has_roadmap": false,
-      "roadmap_source": "none",
-      "open_beads": 0,
-      "status": "planned"
-    },
-    {
       "module": "interpath",
       "location": "interverse/interpath",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -1109,7 +1757,7 @@
     {
       "module": "interphase",
       "location": "interverse/interphase",
-      "version": "0.3.17",
+      "version": "0.3.20",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -1127,7 +1775,7 @@
     {
       "module": "interpub",
       "location": "interverse/interpub",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -1136,7 +1784,7 @@
     {
       "module": "interpulse",
       "location": "interverse/interpulse",
-      "version": "0.1.5",
+      "version": "0.1.10",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -1145,7 +1793,7 @@
     {
       "module": "interrank",
       "location": "interverse/interrank",
-      "version": "0.3.1",
+      "version": "0.3.4",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -1172,7 +1820,7 @@
     {
       "module": "intersearch",
       "location": "interverse/intersearch",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -1199,7 +1847,7 @@
     {
       "module": "intership",
       "location": "interverse/intership",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -1244,7 +1892,7 @@
     {
       "module": "interspect",
       "location": "interverse/interspect",
-      "version": "0.1.22",
+      "version": "0.1.25",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -1253,16 +1901,25 @@
     {
       "module": "interstat",
       "location": "interverse/interstat",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
       "status": "active"
     },
     {
+      "module": "interstate",
+      "location": "interverse/interstate",
+      "version": "0.5.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
       "module": "intersynth",
       "location": "interverse/intersynth",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
@@ -1289,7 +1946,7 @@
     {
       "module": "intertrack",
       "location": "interverse/intertrack",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -1314,9 +1971,27 @@
       "status": "early"
     },
     {
+      "module": "intervoice",
+      "location": "interverse/intervoice",
+      "version": "0.1.1",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "intervox",
+      "location": "interverse/intervox",
+      "version": "0.2.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
       "module": "interwatch",
       "location": "interverse/interwatch",
-      "version": "0.5.0",
+      "version": "0.6.1",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -1334,7 +2009,7 @@
     {
       "module": "tldr-swinton",
       "location": "interverse/tldr-swinton",
-      "version": "0.7.19",
+      "version": "0.8.4",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -1343,7 +2018,7 @@
     {
       "module": "tool-time",
       "location": "interverse/tool-time",
-      "version": "0.4.0",
+      "version": "0.4.3",
       "has_roadmap": true,
       "roadmap_source": "beads",
       "open_beads": 0,
@@ -1366,6 +2041,24 @@
       "roadmap_source": "none",
       "open_beads": 0,
       "status": "planned"
+    },
+    {
+      "module": "Clavain",
+      "location": "os/Clavain",
+      "version": "0.6.293",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
+    },
+    {
+      "module": "Clavain-pub",
+      "location": "os/Clavain-pub",
+      "version": "0.6.294",
+      "has_roadmap": true,
+      "roadmap_source": "beads",
+      "open_beads": 0,
+      "status": "active"
     },
     {
       "module": "Ockham",
@@ -1404,44 +2097,17 @@
       "status": "planned"
     },
     {
-      "module": "Auraken",
-      "location": "apps/Auraken",
-      "version": "0.1.0",
+      "module": "agentic_coding_flywheel_setup",
+      "location": "research/agentic_coding_flywheel_setup",
+      "version": "0.7.0",
       "has_roadmap": false,
       "roadmap_source": "none",
       "open_beads": 0,
       "status": "early"
     },
     {
-      "module": "Autarch",
-      "location": "apps/Autarch",
-      "version": "0.1.0",
-      "has_roadmap": true,
-      "roadmap_source": "beads",
-      "open_beads": 0,
-      "status": "active"
-    },
-    {
-      "module": "Intercom",
-      "location": "apps/Intercom",
-      "version": "1.1.0",
-      "has_roadmap": true,
-      "roadmap_source": "beads",
-      "open_beads": 0,
-      "status": "active"
-    },
-    {
-      "module": "Khouri",
-      "location": "apps/Khouri",
-      "version": "0.1.0",
-      "has_roadmap": true,
-      "roadmap_source": "beads",
-      "open_beads": 0,
-      "status": "active"
-    },
-    {
-      "module": "Meadowsyn",
-      "location": "apps/Meadowsyn",
+      "module": "agi-hyperspace",
+      "location": "research/agi-hyperspace",
       "version": "—",
       "has_roadmap": false,
       "roadmap_source": "none",
@@ -1449,35 +2115,8 @@
       "status": "planned"
     },
     {
-      "module": "interblog",
-      "location": "apps/interblog",
-      "version": "0.1.4",
-      "has_roadmap": false,
-      "roadmap_source": "none",
-      "open_beads": 0,
-      "status": "early"
-    },
-    {
-      "module": "intersite",
-      "location": "apps/intersite",
-      "version": "0.1.0",
-      "has_roadmap": false,
-      "roadmap_source": "none",
-      "open_beads": 0,
-      "status": "early"
-    },
-    {
-      "module": "agent-rig",
-      "location": "core/agent-rig",
-      "version": "0.1.0",
-      "has_roadmap": false,
-      "roadmap_source": "none",
-      "open_beads": 0,
-      "status": "early"
-    },
-    {
-      "module": "interband",
-      "location": "core/interband",
+      "module": "automated_plan_reviser_pro",
+      "location": "research/automated_plan_reviser_pro",
       "version": "—",
       "has_roadmap": false,
       "roadmap_source": "none",
@@ -1485,8 +2124,8 @@
       "status": "planned"
     },
     {
-      "module": "interbench",
-      "location": "core/interbench",
+      "module": "beads_for_cass",
+      "location": "research/beads_for_cass",
       "version": "—",
       "has_roadmap": false,
       "roadmap_source": "none",
@@ -1494,31 +2133,328 @@
       "status": "planned"
     },
     {
-      "module": "intercore",
-      "location": "core/intercore",
+      "module": "beads_rust",
+      "location": "research/beads_rust",
       "version": "—",
-      "has_roadmap": true,
-      "roadmap_source": "beads",
+      "has_roadmap": false,
+      "roadmap_source": "none",
       "open_beads": 0,
-      "status": "active"
+      "status": "planned"
     },
     {
-      "module": "intermute",
-      "location": "core/intermute",
+      "module": "beads_viewer",
+      "location": "research/beads_viewer",
       "version": "—",
-      "has_roadmap": true,
-      "roadmap_source": "beads",
+      "has_roadmap": false,
+      "roadmap_source": "none",
       "open_beads": 0,
-      "status": "active"
+      "status": "planned"
     },
     {
-      "module": "marketplace",
-      "location": "core/marketplace",
+      "module": "beads_viewer_for_agentic_coding_flywheel_setup",
+      "location": "research/beads_viewer_for_agentic_coding_flywheel_setup",
       "version": "—",
-      "has_roadmap": true,
-      "roadmap_source": "beads",
+      "has_roadmap": false,
+      "roadmap_source": "none",
       "open_beads": 0,
-      "status": "active"
+      "status": "planned"
+    },
+    {
+      "module": "beads_viewer-pages",
+      "location": "research/beads_viewer-pages",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "cass_memory_system",
+      "location": "research/cass_memory_system",
+      "version": "0.2.3",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "claude_code_agent_farm",
+      "location": "research/claude_code_agent_farm",
+      "version": "1.0.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "coding_agent_session_search",
+      "location": "research/coding_agent_session_search",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "cross_agent_session_resumer",
+      "location": "research/cross_agent_session_resumer",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "destructive_command_guard",
+      "location": "research/destructive_command_guard",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "fastmcp_rust",
+      "location": "research/fastmcp_rust",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "flywheel_gateway",
+      "location": "research/flywheel_gateway",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "franken_agent_detection",
+      "location": "research/franken_agent_detection",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "frankensearch",
+      "location": "research/frankensearch",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "frankentui",
+      "location": "research/frankentui",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "gastown",
+      "location": "research/gastown",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "gemini-api-updater-doc",
+      "location": "research/gemini-api-updater-doc",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "get-shit-done",
+      "location": "research/get-shit-done",
+      "version": "1.29.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "goosetown",
+      "location": "research/goosetown",
+      "version": "0.1.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "gpt-researcher",
+      "location": "research/gpt-researcher",
+      "version": "0.14.7",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "gsv-portfolio-39",
+      "location": "research/gsv-portfolio-39",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "guide_to_openai_response_api_and_agents_sdk",
+      "location": "research/guide_to_openai_response_api_and_agents_sdk",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "hermes_agent",
+      "location": "research/hermes_agent",
+      "version": "1.0.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "jido",
+      "location": "research/jido",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "llm_docs",
+      "location": "research/llm_docs",
+      "version": "0.1.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "llm_multi_round_coding_tournament",
+      "location": "research/llm_multi_round_coding_tournament",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "mcp_agent_mail",
+      "location": "research/mcp_agent_mail",
+      "version": "0.3.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "mcp_agent_mail_rust",
+      "location": "research/mcp_agent_mail_rust",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "meta_skill",
+      "location": "research/meta_skill",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "ntm",
+      "location": "research/ntm",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "pi_agent_rust",
+      "location": "research/pi_agent_rust",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "pi-autoresearch",
+      "location": "research/pi-autoresearch",
+      "version": "1.0.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "pi-mono",
+      "location": "research/pi-mono",
+      "version": "0.0.3",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "post_compact_reminder",
+      "location": "research/post_compact_reminder",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "slb",
+      "location": "research/slb",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
+    },
+    {
+      "module": "ultimate_bug_scanner",
+      "location": "research/ultimate_bug_scanner",
+      "version": "0.0.0",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "early"
+    },
+    {
+      "module": "your-source-to-prompt.html",
+      "location": "research/your-source-to-prompt.html",
+      "version": "—",
+      "has_roadmap": false,
+      "roadmap_source": "none",
+      "open_beads": 0,
+      "status": "planned"
     },
     {
       "module": "interbase",
@@ -1530,7 +2466,7 @@
       "status": "active"
     },
     {
-      "module": "demarch",
+      "module": "sylveste",
       "location": "root",
       "version": "—",
       "has_roadmap": true,
@@ -1542,754 +2478,6319 @@
   "roadmap": {
     "now": [
       {
-        "module": "Remontoire",
-        "id": "Revel-6ep.9",
-        "title": "Release review and live approved canary",
+        "module": "sylveste",
+        "id": "sylveste-myyw.16",
+        "title": "A:L3 receipt proof gate — observe 10 natural no-touch sprints",
+        "phase": "now",
+        "priority": "P0",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "A:L3 receipt proof gate — observe 10 natural no-touch sprints"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-iaqg",
+        "title": "Pre-Launch Readiness epic — test scaffolding, kill-switch tests, telemetry, contract pinning, link checks, spec-policy, rollback tests, privacy threat model",
+        "phase": "now",
+        "priority": "P0",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Pre-Launch Readiness epic — test scaffolding, kill-switch tests, telemetry, contract pinning, link checks, spec-policy, rollback tests, privacy threat model"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-myyw",
+        "title": "Autonomy A:L3 — all three calibration loops fire without human invocation",
+        "phase": "now",
+        "priority": "P0",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Autonomy A:L3 — all three calibration loops fire without human invocation"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-22oi",
+        "title": "Auraken → Hermes overlay: strategic epic",
+        "phase": "now",
+        "priority": "P0",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-4vbg"
+        ],
+        "notes": "Auraken → Hermes overlay: strategic epic"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-benl.10",
+        "title": "Shared user identity + profile database",
+        "phase": "now",
+        "priority": "P0",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Shared user identity + profile database"
+      },
+      {
+        "module": "epic",
+        "id": "sylveste-benl",
+        "title": "Auraken → Skaffen: migrate intelligence layer to Go ecosystem",
+        "phase": "now",
+        "priority": "P0",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Auraken → Skaffen: migrate intelligence layer to Go ecosystem"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-tapb",
+        "title": "Clavain publish blocked: intercore worktree dirty fails release-binary verification",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Clavain publish blocked: intercore worktree dirty fails release-binary verification"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-tozs",
+        "title": "zklw clavain-cli emits policy schema 1 — every gate fails closed as 'malformed policy'",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "zklw clavain-cli emits policy schema 1 — every gate fails closed as 'malformed policy'"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-06i.4",
+        "title": "Build LLM-judge reliability harness for flux-drive panel (kill-rule FAIL mandate)",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Build LLM-judge reliability harness for flux-drive panel (kill-rule FAIL mandate)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-qi6",
+        "title": "jawncite schema design spec (resolves doctrine's 6 open questions)",
+        "phase": "now",
+        "priority": "P1",
+        "status": "in_progress",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "jawncite schema design spec (resolves doctrine's 6 open questions)"
+      },
+      {
+        "module": "beads",
+        "id": "sylveste-bkrh",
+        "title": "Align Sylveste tracker remotes across Mac and zklw",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Align Sylveste tracker remotes across Mac and zklw"
+      },
+      {
+        "module": "intercore",
+        "id": "sylveste-5xpi",
+        "title": "Implement multi-key verification and enforced quarantine semantics",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Implement multi-key verification and enforced quarantine semantics"
+      },
+      {
+        "module": "intercore",
+        "id": "sylveste-mn13",
+        "title": "Cryptographically anchor legacy vintage against sig_version downgrade",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Cryptographically anchor legacy vintage against sig_version downgrade"
+      },
+      {
+        "module": "upstream-sync",
+        "id": "Sylveste-ie6.10",
+        "title": "interlock: FULL protocol sync to mcp_agent_mail v0.3.4 (breaking, multi-session)",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "interlock: FULL protocol sync to mcp_agent_mail v0.3.4 (breaking, multi-session)"
+      },
+      {
+        "module": "upstream-sync",
+        "id": "Sylveste-ie6.8",
+        "title": "beads v1.0.4 adopt: repo move + export config + post-pull auto-import",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "beads v1.0.4 adopt: repo move + export config + post-pull auto-import"
+      },
+      {
+        "module": "upstream-sync",
+        "id": "Sylveste-ie6.9",
+        "title": "oracle v0.15.0 adopt: --allow-partial, path:line citations, repo .oracle/config.json",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "oracle v0.15.0 adopt: --allow-partial, path:line citations, repo .oracle/config.json"
+      },
+      {
+        "module": "epic",
+        "id": "Sylveste-ie6",
+        "title": "upstream-sync 2026-06: superpowers v4to6, compound to v3.13.1",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "upstream-sync 2026-06: superpowers v4to6, compound to v3.13.1"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-4b5.1",
+        "title": "Consensus-trap breaker on interspect's adaptive calibration loop",
         "phase": "now",
         "priority": "P1",
         "status": "blocked",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [
-          "Revel-6ep.8"
+          "sylveste-9lp.37"
         ],
-        "notes": "Release review and live approved canary"
+        "notes": "Consensus-trap breaker on interspect's adaptive calibration loop"
       },
       {
         "module": "sylveste",
-        "id": "Revel-6ep",
-        "title": "Remontoire v0.1: bounded autonomous portfolio agency",
-        "phase": "now",
-        "priority": "P1",
-        "status": "in_progress",
-        "source": "beads",
-        "source_file": "beads",
-        "blocked_by": [],
-        "notes": "Remontoire v0.1: bounded autonomous portfolio agency"
-      },
-      {
-        "module": "Theme",
-        "id": "shadow-work-5swd",
-        "title": "Demo Ship — Polish, package, and distribute the Prometheus Crisis demo",
+        "id": "Sylveste-4b5",
+        "title": "Agentic-frontier roadmap delta (2026-06-21) — 24 survivors from frontier×backlog gap analysis",
         "phase": "now",
         "priority": "P1",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Demo Ship — Polish, package, and distribute the Prometheus Crisis demo"
+        "notes": "Agentic-frontier roadmap delta (2026-06-21) — 24 survivors from frontier×backlog gap analysis"
       },
       {
-        "module": "Epic",
-        "id": "shadow-work-dh7t",
-        "title": "v1 Ship — Polish and package the Prometheus Crisis demo",
+        "module": "interspect",
+        "id": "sylveste-7ttr",
+        "title": "Wire signed receipts to proposal + canary-evaluation paths (ewy3.5.4 remainder)",
         "phase": "now",
         "priority": "P1",
-        "status": "open",
+        "status": "blocked",
         "source": "beads",
         "source_file": "beads",
-        "blocked_by": [],
-        "notes": "v1 Ship — Polish and package the Prometheus Crisis demo"
+        "blocked_by": [
+          "Sylveste-4b5.12",
+          "Sylveste-4b5.13"
+        ],
+        "notes": "Wire signed receipts to proposal + canary-evaluation paths (ewy3.5.4 remainder)"
       },
       {
         "module": "sylveste",
-        "id": "Revel-1zh",
-        "title": "LLM Curator — Claude as cultural advisor via sidecar",
+        "id": "sylveste-22oi.7.6",
+        "title": "Cognitive profile: governance surface (consent + /profile + export + erasure + retention)",
         "phase": "now",
         "priority": "P1",
-        "status": "open",
+        "status": "blocked",
         "source": "beads",
         "source_file": "beads",
-        "blocked_by": [],
-        "notes": "LLM Curator — Claude as cultural advisor via sidecar"
+        "blocked_by": [
+          "sylveste-22oi.7.2"
+        ],
+        "notes": "Cognitive profile: governance surface (consent + /profile + export + erasure + retention)"
       },
       {
         "module": "sylveste",
-        "id": "Revel-flg",
-        "title": "Revel engine — feast with performance",
+        "id": "sylveste-22oi.7",
+        "title": "Auraken user cognitive profile (v0.2 pattern-awareness substrate / moat #2)",
         "phase": "now",
         "priority": "P1",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Revel engine — feast with performance"
+        "notes": "Auraken user cognitive profile (v0.2 pattern-awareness substrate / moat #2)"
       },
       {
         "module": "sylveste",
-        "id": "Revel-zps",
-        "title": "Composition system — elves create art at workshops",
+        "id": "sylveste-xogc",
+        "title": "Beads durability: JSONL->DB restore + periodic integrity check",
         "phase": "now",
         "priority": "P1",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Composition system — elves create art at workshops"
+        "notes": "Beads durability: JSONL->DB restore + periodic integrity check"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-owjn",
+        "title": "Ecosystem improvement analysis + roadmap refresh + Anthropic feedback",
+        "phase": "now",
+        "priority": "P1",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "Sylveste-4b5.12"
+        ],
+        "notes": "Ecosystem improvement analysis + roadmap refresh + Anthropic feedback"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-22oi.2",
+        "title": "Auraken v0.2: Flip mistakeknot/auraken repo to public + verify curl install path",
+        "phase": "now",
+        "priority": "P1",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Auraken v0.2: Flip mistakeknot/auraken repo to public + verify curl install path"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-ewy3.4.1",
+        "title": "Implement A2A native transport at apps/Intercom/go/internal/transport/a2a/",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Implement A2A native transport at apps/Intercom/go/internal/transport/a2a/"
+      },
+      {
+        "module": "clavain",
+        "id": "sylveste-3kol",
+        "title": "Rimsky: N-parallel sprint orchestrator over interlock + worktrees (gstack import)",
+        "phase": "now",
+        "priority": "P1",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "Sylveste-4b5.7",
+          "Sylveste-4b5.8",
+          "Sylveste-4b5.17"
+        ],
+        "notes": "Rimsky: N-parallel sprint orchestrator over interlock + worktrees (gstack import)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-xoki",
+        "title": "Codex/Claude Code performance and reliability hardening",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Codex/Claude Code performance and reliability hardening"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-3xl3.1",
+        "title": "flux-explore --teams: cross-domain debate mode (highest-leverage match)",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "flux-explore --teams: cross-domain debate mode (highest-leverage match)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-3xl3",
+        "title": "Agent Teams (Claude Code) integration across Sylveste — Interflux first",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Agent Teams (Claude Code) integration across Sylveste — Interflux first"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-xp7",
+        "title": "Make multi-agent coordination autonomous (auto-join, auto-check, daemon liveness)",
+        "phase": "now",
+        "priority": "P1",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "Sylveste-sox",
+          "Sylveste-rly",
+          "Sylveste-5r1"
+        ],
+        "notes": "Make multi-agent coordination autonomous (auto-join, auto-check, daemon liveness)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-mj11",
+        "title": "Vision v6 — integrate 04-26 lens findings into specification",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Vision v6 — integrate 04-26 lens findings into specification"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-jdnh",
+        "title": "F1: Kernel subsystem-event surface (table + SourceSubsystem + CLI)",
+        "phase": "now",
+        "priority": "P1",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-8r5h",
+          "sylveste-xofc"
+        ],
+        "notes": "F1: Kernel subsystem-event surface (table + SourceSubsystem + CLI)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-fd7x",
+        "title": "Ecosystem audit remediation: compile, plugin, workflow, and autonomy gaps",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Ecosystem audit remediation: compile, plugin, workflow, and autonomy gaps"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-mij3",
+        "title": "Install sqlite3 CLI on zklw + re-derive cost-per-landable-change baseline",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Install sqlite3 CLI on zklw + re-derive cost-per-landable-change baseline"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-whyj",
+        "title": "Ingest Signal messages into interfluence voice corpus — conversational register calibration",
+        "phase": "now",
+        "priority": "P1",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-22oi"
+        ],
+        "notes": "Ingest Signal messages into interfluence voice corpus — conversational register calibration"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-lfdy",
+        "title": "Generalize Auraken register across model families (Claude / GPT / future)",
+        "phase": "now",
+        "priority": "P1",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-whyj",
+          "sylveste-dz94",
+          "sylveste-22oi",
+          "sylveste-khb8",
+          "sylveste-4wq6"
+        ],
+        "notes": "Generalize Auraken register across model families (Claude / GPT / future)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-krop",
+        "title": "Per-project / per-skill lazy MCP enablement design (spike D)",
+        "phase": "now",
+        "priority": "P1",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-116u"
+        ],
+        "notes": "Per-project / per-skill lazy MCP enablement design (spike D)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-t8rn",
+        "title": "Ockham F7 health bypass — health JSON + Tier 3 BYPASS (fzt successor)",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Ockham F7 health bypass — health JSON + Tier 3 BYPASS (fzt successor)"
+      },
+      {
+        "module": "epic",
+        "id": "sylveste-fyo3",
+        "title": "interflux agent persistence & multi-model activation",
+        "phase": "now",
+        "priority": "P1",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "Sylveste-4b5.10"
+        ],
+        "notes": "interflux agent persistence & multi-model activation"
+      },
+      {
+        "module": "fd",
+        "id": "sylveste-foui",
+        "title": "F5: Add per-source freshness timestamps to QueryResult.metadata",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "F5: Add per-source freshness timestamps to QueryResult.metadata"
+      },
+      {
+        "module": "fd",
+        "id": "sylveste-dkx7",
+        "title": "F5: Add unresolved_entities field — session_entities must not silently drop crosswalk misses",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "F5: Add unresolved_entities field — session_entities must not silently drop crosswalk misses"
+      },
+      {
+        "module": "fd",
+        "id": "sylveste-01cu",
+        "title": "F5: Document temporal scope boundaries per template — cass coverage start date",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "F5: Document temporal scope boundaries per template — cass coverage start date"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-benl.9",
+        "title": "Analysis mode (Westworld-style host debugging)",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Analysis mode (Westworld-style host debugging)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-benl.7",
+        "title": "Migrate Telegram transport from Auraken to Intercom",
+        "phase": "now",
+        "priority": "P1",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-2nfd"
+        ],
+        "notes": "Migrate Telegram transport from Auraken to Intercom"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-benl.8",
+        "title": "Define Auraken as a Skaffen agent configuration",
+        "phase": "now",
+        "priority": "P1",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-4vbg"
+        ],
+        "notes": "Define Auraken as a Skaffen agent configuration"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-benl.5",
+        "title": "Port profile generation to Go",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Port profile generation to Go"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-benl.6",
+        "title": "Add Signal transport to Intercom",
+        "phase": "now",
+        "priority": "P1",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-2nfd"
+        ],
+        "notes": "Add Signal transport to Intercom"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-agr2",
+        "title": "Signal command: undo (revert last applied commit)",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Signal command: undo (revert last applied commit)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-nr6x",
+        "title": "Hassease: multi-model code execution daemon (Signal-native, cost-routed)",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Hassease: multi-model code execution daemon (Signal-native, cost-routed)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-b6j7",
+        "title": "Signal command: status (show current state)",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Signal command: status (show current state)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-wcl1",
+        "title": "Backup before forge apply (git stash)",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Backup before forge apply (git stash)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-rcn8",
+        "title": "Auraken companion agent research: Soren, Auren, Pi, Replika patterns",
+        "phase": "now",
+        "priority": "P1",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Auraken companion agent research: Soren, Auren, Pi, Replika patterns"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-46s",
+        "title": "interweave: generative ontology graph for agentic platforms",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "interweave: generative ontology graph for agentic platforms"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.16",
+        "title": "P2: Research mode parity — add peer findings, reaction round, sycophancy detection to research path",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "P2: Research mode parity — add peer findings, reaction round, sycophancy detection to research path"
+      },
+      {
+        "module": "epic",
+        "id": "sylveste-9lp",
+        "title": "interflux roadmap — correctness, cost, cross-model, UX, architecture",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "interflux roadmap — correctness, cost, cross-model, UX, architecture"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-18a.4",
+        "title": "Port coordinator prompt structure to OODARC phase system prompts",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Port coordinator prompt structure to OODARC phase system prompts"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-18a.2",
+        "title": "Streaming tool execution for Skaffen agentloop",
+        "phase": "now",
+        "priority": "P1",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-18a.1"
+        ],
+        "notes": "Streaming tool execution for Skaffen agentloop"
+      },
+      {
+        "module": "skaffen",
+        "id": "sylveste-18a",
+        "title": "Claude Code parity patterns epic: streaming exec, coordinator prompts, permission modes, fork-cache, MCP transports",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Claude Code parity patterns epic: streaming exec, coordinator prompts, permission modes, fork-cache, MCP transports"
+      },
+      {
+        "module": "auraken",
+        "id": "sylveste-2l1.2",
+        "title": "Run lens selection on daily_dilemmas — build anchor suite",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Run lens selection on daily_dilemmas — build anchor suite"
+      },
+      {
+        "module": "auraken",
+        "id": "sylveste-2l1",
+        "title": "Lens selection calibration — external dataset pipeline",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Lens selection calibration — external dataset pipeline"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-rwk",
+        "title": "Voice pass: project page copy through Texturaize + interfluence",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Voice pass: project page copy through Texturaize + interfluence"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-bid",
+        "title": "intersite-voice: voice pass, about page, experiment publish",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "intersite-voice: voice pass, about page, experiment publish"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-1of",
+        "title": "Refactor interseed from SQLite to git-native markdown",
+        "phase": "now",
+        "priority": "P1",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Refactor interseed from SQLite to git-native markdown"
       }
     ],
     "next": [
       {
         "module": "sylveste",
-        "id": "shadow-work-eby1",
-        "title": "Scenario Assertion Protocol — canonical crisis scenarios with pressure threshold targets for L3 maturity",
+        "id": "Sylveste-oxcv",
+        "title": "A negative-control proof cannot tell 'assertion failed' from 'fork failed', so 7 of 9 results are unknown",
         "phase": "next",
         "priority": "P2",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Scenario Assertion Protocol — canonical crisis scenarios with pressure threshold targets for L3 maturity"
-      },
-      {
-        "module": "Theme",
-        "id": "shadow-work-whlc",
-        "title": "Content & Scenarios — Authored gameplay content from ARCHITECTURE specs",
-        "phase": "next",
-        "priority": "P2",
-        "status": "open",
-        "source": "beads",
-        "source_file": "beads",
-        "blocked_by": [],
-        "notes": "Content & Scenarios — Authored gameplay content from ARCHITECTURE specs"
-      },
-      {
-        "module": "Theme",
-        "id": "shadow-work-4wdr",
-        "title": "Emergence & Integration — Feedback loops, cross-system testing, validation",
-        "phase": "next",
-        "priority": "P2",
-        "status": "open",
-        "source": "beads",
-        "source_file": "beads",
-        "blocked_by": [],
-        "notes": "Emergence & Integration — Feedback loops, cross-system testing, validation"
-      },
-      {
-        "module": "Theme",
-        "id": "shadow-work-jxnz",
-        "title": "Agent Sim Fidelity — Personality, memory, ideology, actions, recruitment",
-        "phase": "next",
-        "priority": "P2",
-        "status": "open",
-        "source": "beads",
-        "source_file": "beads",
-        "blocked_by": [],
-        "notes": "Agent Sim Fidelity — Personality, memory, ideology, actions, recruitment"
-      },
-      {
-        "module": "Theme",
-        "id": "shadow-work-jol0",
-        "title": "Gameplay & UX — UI polish, interaction design, and player experience",
-        "phase": "next",
-        "priority": "P2",
-        "status": "open",
-        "source": "beads",
-        "source_file": "beads",
-        "blocked_by": [],
-        "notes": "Gameplay & UX — UI polish, interaction design, and player experience"
-      },
-      {
-        "module": "Theme",
-        "id": "shadow-work-93mh",
-        "title": "Renderer & Graphics — Bevy renderer, MetalFX upscaling, visual polish",
-        "phase": "next",
-        "priority": "P2",
-        "status": "open",
-        "source": "beads",
-        "source_file": "beads",
-        "blocked_by": [],
-        "notes": "Renderer & Graphics — Bevy renderer, MetalFX upscaling, visual polish"
-      },
-      {
-        "module": "Epic",
-        "id": "shadow-work-fmw0",
-        "title": "Graduating Narrative Judge — seed gate + LLM judge + trained classifier for Level 4 validation",
-        "phase": "next",
-        "priority": "P2",
-        "status": "open",
-        "source": "beads",
-        "source_file": "beads",
-        "blocked_by": [],
-        "notes": "Graduating Narrative Judge — seed gate + LLM judge + trained classifier for Level 4 validation"
+        "notes": "A negative-control proof cannot tell 'assertion failed' from 'fork failed', so 7 of 9 results are unknown"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-xjop",
-        "title": "Epic: Forecasted Timeline System Tracing adapter for Shadow Work",
+        "id": "Sylveste-2fu3",
+        "title": "shadow-work: 17-line hook repair awaiting mk's commit in a third-party-org repo",
         "phase": "next",
         "priority": "P2",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Epic: Forecasted Timeline System Tracing adapter for Shadow Work"
-      },
-      {
-        "module": "Epic",
-        "id": "shadow-work-ac5b",
-        "title": "2025-2525 scenario planning — Generate and refine issue corpus",
-        "phase": "next",
-        "priority": "P2",
-        "status": "open",
-        "source": "beads",
-        "source_file": "beads",
-        "blocked_by": [],
-        "notes": "2025-2525 scenario planning — Generate and refine issue corpus"
+        "notes": "shadow-work: 17-line hook repair awaiting mk's commit in a third-party-org repo"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-3ek3",
-        "title": "Test: Completeness gap validation",
+        "id": "Sylveste-9yoh",
+        "title": "intercore: ic sweep — wire the 4 implemented-never-wired subsystems (scheduler engine, stall detector, RecoverPending, audit chain) with per-subsystem witness obligations (f-158)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "intercore: ic sweep — wire the 4 implemented-never-wired subsystems (scheduler engine, stall detector, RecoverPending, audit chain) with per-subsystem witness obligations (f-158)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-cayt",
+        "title": "Clavain: gate-mode 3-file fix — unify bash/Go defaults, emit gate_mode_resolved via ic events record, write failure-direction policy into contracts/ (f-101/f-102/f-108)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Clavain: gate-mode 3-file fix — unify bash/Go defaults, emit gate_mode_resolved via ic events record, write failure-direction policy into contracts/ (f-101/f-102/f-108)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-hni3",
+        "title": "Clavain: SYLVESTE_EXEMPLAR_ROOT detection helper routed through ensure_repo, codex-auto-refresh, check-install-updates (f-084/f-085/f-052)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Clavain: SYLVESTE_EXEMPLAR_ROOT detection helper routed through ensure_repo, codex-auto-refresh, check-install-updates (f-084/f-085/f-052)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-qgvl",
+        "title": "intercore: wire audit chain to gate-mode resolutions + dispatch transitions (run-scoped chains, LogQ tx variant, checksum policy v2 — f-188)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "intercore: wire audit chain to gate-mode resolutions + dispatch transitions (run-scoped chains, LogQ tx variant, checksum policy v2 — f-188)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-so2i",
+        "title": "intercore: ClearLocks staleness guard + --dry-run + classified tombstone event (f-060, f-192)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "intercore: ClearLocks staleness guard + --dry-run + classified tombstone event (f-060, f-192)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-tfvr",
+        "title": "bd cannot open the beads database in Nartopo and mediumsetting: pending schema migrations on dirty tables",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "bd cannot open the beads database in Nartopo and mediumsetting: pending schema migrations on dirty tables"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-ttlq",
+        "title": "rig-autosync-freshness.py is tracked but declared in neither installer nor the health surface",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "rig-autosync-freshness.py is tracked but declared in neither installer nor the health surface"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-ddp3",
+        "title": "rig-hook-wiring.py and rig-hook-duplication.py are tracked but declared in neither installer",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "rig-hook-wiring.py and rig-hook-duplication.py are tracked but declared in neither installer"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-fsdy",
+        "title": "Two hook scripts are present on both machines and registered nowhere",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Two hook scripts are present on both machines and registered nowhere"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-g1cu",
+        "title": "publish drift: shipped artifact behind committed source (2026-08-03)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "publish drift: shipped artifact behind committed source (2026-08-03)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-2fhj",
+        "title": "rig-hook-wiring.py is tracked but declared in neither installer and not in the health surface",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "rig-hook-wiring.py is tracked but declared in neither installer and not in the health surface"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-8tfd",
+        "title": "Two hook scripts are present on both machines and registered nowhere",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Two hook scripts are present on both machines and registered nowhere"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-y6rl",
+        "title": "Nothing stops a commit from adding a tracked dotfiles path with no declaration",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Nothing stops a commit from adding a tracked dotfiles path with no declaration"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-bvoy",
+        "title": "publish drift: shipped artifact behind committed source (2026-08-02)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "publish drift: shipped artifact behind committed source (2026-08-02)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-keb3",
+        "title": "Six beads differ between the machines in ways no import can reconcile",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Six beads differ between the machines in ways no import can reconcile"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-6ko4",
+        "title": "Re-measure auto-stop-actions timeout rate once clavain 0.6.294 is resolved in-session",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Re-measure auto-stop-actions timeout rate once clavain 0.6.294 is resolved in-session"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-8umf",
+        "title": "Unknown clavain-cli flags are silently ignored instead of rejected",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Unknown clavain-cli flags are silently ignored instead of rejected"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-hvkl",
+        "title": "dotfiles vendors obra/superpowers as a split tree — pin an upstream ref instead?",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "dotfiles vendors obra/superpowers as a split tree — pin an upstream ref instead?"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-84by",
+        "title": "git-autosync-promote reports NEEDS-REBASE for lanes that are strict ancestors of main",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "git-autosync-promote reports NEEDS-REBASE for lanes that are strict ancestors of main"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-4vol",
+        "title": "secret scanner: the X_SECRET_Y= class still slides past the generic rule",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "secret scanner: the X_SECRET_Y= class still slides past the generic rule"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-ws38",
+        "title": "auraken local history is unrelated to its remote — hook fix cannot be pushed",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "auraken local history is unrelated to its remote — hook fix cannot be pushed"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-j7vl",
+        "title": "cc-changelog: unreviewed Claude Code releases (2.1.216 → 2.1.220)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "cc-changelog: unreviewed Claude Code releases (2.1.216 → 2.1.220)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-kp9o",
+        "title": "Khouri lane frozen 109 days — mk to decide on f985d94",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Khouri lane frozen 109 days — mk to decide on f985d94"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-r3xs",
+        "title": "Adopt --to auto --class at remaining dispatch call sites (phase 1.5)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Adopt --to auto --class at remaining dispatch call sites (phase 1.5)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-gtqg",
+        "title": "New plugin repos start unprotected — nothing enforces the branch-protection policy as an invariant",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "New plugin repos start unprotected — nothing enforces the branch-protection policy as an invariant"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-0pk",
+        "title": "/model-routing economy|quality seds flatten routing-table v2 phase overrides",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "/model-routing economy|quality seds flatten routing-table v2 phase overrides"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-2ys",
+        "title": "clavain create-agent-skill command references a missing skill",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "clavain create-agent-skill command references a missing skill"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-d3m",
+        "title": "Adopt --to auto --class across Clavain dispatch (phase 1: shadow wiring)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Adopt --to auto --class across Clavain dispatch (phase 1: shadow wiring)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-v7f",
+        "title": "Add kimi as a flux-melange peer runtime (HTTP transport, no CLI)",
         "phase": "next",
         "priority": "P2",
         "status": "in_progress",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Test: Completeness gap validation"
-      },
-      {
-        "module": "Epic",
-        "id": "shadow-work-o79m",
-        "title": "Scenario authoring — Playable game content from ARCHITECTURE specs",
-        "phase": "next",
-        "priority": "P2",
-        "status": "open",
-        "source": "beads",
-        "source_file": "beads",
-        "blocked_by": [],
-        "notes": "Scenario authoring — Playable game content from ARCHITECTURE specs"
+        "notes": "Add kimi as a flux-melange peer runtime (HTTP transport, no CLI)"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-t84f.5",
-        "title": "Consolidate emergence data hooks into shared event-driven state",
+        "id": "Sylveste-rhw",
+        "title": "Route charter-vs-plain-goal from goal risk properties (wire classifyComplexity + spend signal into the goal-form fork)",
         "phase": "next",
         "priority": "P2",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Consolidate emergence data hooks into shared event-driven state"
+        "notes": "Route charter-vs-plain-goal from goal risk properties (wire classifyComplexity + spend signal into the goal-form fork)"
+      },
+      {
+        "module": "infra",
+        "id": "Sylveste-bzy",
+        "title": "5 interverse plugins dual-tracked: force-added into monorepo AND published from independent repos (interfer, interhelm, intersight, interseed, intership)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "5 interverse plugins dual-tracked: force-added into monorepo AND published from independent repos (interfer, interhelm, intersight, interseed, intership)"
+      },
+      {
+        "module": "infra",
+        "id": "Sylveste-6f7",
+        "title": "zklw Go toolchain (1.23.8) too old to build intercore (go 1.25.0) + darwin release binaries — blocks canary-registering ic and Clavain publish from zklw",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "zklw Go toolchain (1.23.8) too old to build intercore (go 1.25.0) + darwin release binaries — blocks canary-registering ic and Clavain publish from zklw"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-t84f.4",
-        "title": "Narrow GameService and diagnostics reads to avoid whole-state clones",
+        "id": "Sylveste-wch",
+        "title": "Beads Session Close Protocol text is wrong: 'bd backup sync' does not flush Dolt→JSONL — protocol must use 'bd export > .beads/issues.jsonl'",
         "phase": "next",
         "priority": "P2",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Narrow GameService and diagnostics reads to avoid whole-state clones"
+        "notes": "Beads Session Close Protocol text is wrong: 'bd backup sync' does not flush Dolt→JSONL — protocol must use 'bd export > .beads/issues.jsonl'"
+      },
+      {
+        "module": "interverse",
+        "id": "Sylveste-ktz",
+        "title": "Post-baseline small-fix bundle: date -d fallbacks (Sylveste-a3a) + ic publish --cwd hard-error (Sylveste-1zu) + legacy /tmp sideband retirement (Sylveste-zlc)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Post-baseline small-fix bundle: date -d fallbacks (Sylveste-a3a) + ic publish --cwd hard-error (Sylveste-1zu) + legacy /tmp sideband retirement (Sylveste-zlc)"
+      },
+      {
+        "module": "interline",
+        "id": "Sylveste-nko",
+        "title": "Exploit new display surfaces: MessageDisplay hook, terminalSequence, subagentStatusLine effort field",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Exploit new display surfaces: MessageDisplay hook, terminalSequence, subagentStatusLine effort field"
+      },
+      {
+        "module": "intercore",
+        "id": "Sylveste-nwv",
+        "title": "ic publish: adopt 'claude plugin tag' release tagging + plugin dependency metadata + projected context cost surfacing",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "ic publish: adopt 'claude plugin tag' release tagging + plugin dependency metadata + projected context cost surfacing"
+      },
+      {
+        "module": "intermux",
+        "id": "Sylveste-oqo",
+        "title": "Replace session scraping with native 'claude agents --json' (2.1.145) + agent view integration",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Replace session scraping with native 'claude agents --json' (2.1.145) + agent view integration"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-t84f.3",
-        "title": "Reduce per-tick country snapshot cloning in simulation loop",
+        "id": "Sylveste-c7a",
+        "title": "interline: interphase sideband writer redundancy — cutover checklist for interphase retirement",
         "phase": "next",
         "priority": "P2",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Reduce per-tick country snapshot cloning in simulation loop"
+        "notes": "interline: interphase sideband writer redundancy — cutover checklist for interphase retirement"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-t84f.1",
-        "title": "De-hotpath and split OptimizedDataTable",
+        "id": "Sylveste-kq4",
+        "title": "Interband sideband parity from sprint-advance",
         "phase": "next",
         "priority": "P2",
-        "status": "open",
+        "status": "in_progress",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "De-hotpath and split OptimizedDataTable"
-      },
-      {
-        "module": "Epic",
-        "id": "shadow-work-t84f",
-        "title": "Refactor hot paths and structural debt",
-        "phase": "next",
-        "priority": "P2",
-        "status": "open",
-        "source": "beads",
-        "source_file": "beads",
-        "blocked_by": [],
-        "notes": "Refactor hot paths and structural debt"
+        "notes": "Interband sideband parity from sprint-advance"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-th9z",
-        "title": "TUI: Alert banner and auto-pause interrupt",
+        "id": "Sylveste-41r",
+        "title": "Wire OPENROUTER_API_KEY into openrouter-dispatch MCP server env",
         "phase": "next",
         "priority": "P2",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "TUI: Alert banner and auto-pause interrupt"
+        "notes": "Wire OPENROUTER_API_KEY into openrouter-dispatch MCP server env"
       },
       {
         "module": "sylveste",
-        "id": "Revel-8nr",
-        "title": "Game feel: player direction + spatial meaning",
+        "id": "Sylveste-65j",
+        "title": "Record generating-model provenance in flux-drive fd-* output format",
         "phase": "next",
         "priority": "P2",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Game feel: player direction + spatial meaning"
+        "notes": "Record generating-model provenance in flux-drive fd-* output format"
       },
       {
-        "module": "Post-v1",
-        "id": "shadow-work-7xs",
-        "title": "Web distribution — adaptive agent scaling (Phase 2)",
+        "module": "sylveste",
+        "id": "Sylveste-06i.3",
+        "title": "Covert-channel / steganographic collusion audit for interlock messaging",
         "phase": "next",
         "priority": "P2",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Web distribution — adaptive agent scaling (Phase 2)"
+        "notes": "Covert-channel / steganographic collusion audit for interlock messaging"
       },
       {
-        "module": "Post-v1",
-        "id": "shadow-work-nla",
-        "title": "Web distribution — WASM with threaded simulation (Phase 1)",
+        "module": "sylveste",
+        "id": "Sylveste-06i.2",
+        "title": "MAST-taxonomy classification pass over interflux/interlock failure logs",
         "phase": "next",
         "priority": "P2",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Web distribution — WASM with threaded simulation (Phase 1)"
+        "notes": "MAST-taxonomy classification pass over interflux/interlock failure logs"
       },
       {
-        "module": "Post-v1",
-        "id": "shadow-work-sfj",
-        "title": "Additional scenarios",
+        "module": "sylveste",
+        "id": "Sylveste-06i",
+        "title": "Ecosystem research scan: 31-component research-possibilities agenda (3 lenses)",
         "phase": "next",
         "priority": "P2",
-        "status": "open",
+        "status": "in_progress",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Additional scenarios"
+        "notes": "Ecosystem research scan: 31-component research-possibilities agenda (3 lenses)"
       },
       {
-        "module": "Post-v1",
-        "id": "shadow-work-v4r",
-        "title": "Agent recruitment system",
+        "module": "interwatch",
+        "id": "sylveste-mxns",
+        "title": "6 doc(s) drifted from source (weekly scan)",
         "phase": "next",
         "priority": "P2",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Agent recruitment system"
+        "notes": "6 doc(s) drifted from source (weekly scan)"
       },
       {
-        "module": "Post-v1",
-        "id": "shadow-work-y86",
-        "title": "Save/load system",
+        "module": "interlab",
+        "id": "sylveste-4jmp",
+        "title": "Make plugin quality sweep read-only and reproducible",
         "phase": "next",
         "priority": "P2",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Save/load system"
+        "notes": "Make plugin quality sweep read-only and reproducible"
       },
       {
-        "module": "Post-v1",
-        "id": "shadow-work-y03",
-        "title": "Deepen the gameplay loop",
+        "module": "clavain",
+        "id": "sylveste-otv9",
+        "title": "Retire ambiguous home-ledger fallback without losing historical runs",
         "phase": "next",
         "priority": "P2",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Deepen the gameplay loop"
+        "notes": "Retire ambiguous home-ledger fallback without losing historical runs"
       },
       {
-        "module": "Demo",
-        "id": "shadow-work-0ql",
-        "title": "Build and package Tauri desktop binary",
+        "module": "clavain",
+        "id": "sylveste-dan6",
+        "title": "Design remote signer or canonical ledger replication for Mac-originated operations",
         "phase": "next",
         "priority": "P2",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Build and package Tauri desktop binary"
+        "notes": "Design remote signer or canonical ledger replication for Mac-originated operations"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-npc5",
+        "title": "Repair stale Claude plugin commit metadata during deploy",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Repair stale Claude plugin commit metadata during deploy"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-dvw",
+        "title": "Research spike: execute pre-registered F6b flux-drive triage A/B (sylveste-g939)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Research spike: execute pre-registered F6b flux-drive triage A/B (sylveste-g939)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-rgj",
+        "title": "Research spike: null test — does multi-agent coordination beat single-strong-model on our task mix?",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Research spike: null test — does multi-agent coordination beat single-strong-model on our task mix?"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-x2c",
+        "title": "Research spike: re-test 'MLX has no concurrent inference' premise (mlx-lm 0.18+) before sylveste-4wl burns on it",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Research spike: re-test 'MLX has no concurrent inference' premise (mlx-lm 0.18+) before sylveste-4wl burns on it"
+      },
+      {
+        "module": "upstream-sync",
+        "id": "Sylveste-ie6.11",
+        "title": "sp-lab: tombstone dead slack-messaging skill + vendor new windows-vm skill",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "sp-lab: tombstone dead slack-messaging skill + vendor new windows-vm skill"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-qm2",
+        "title": "interlock tier-2: embedding-based semantic conflict detection in pre-edit hook",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "interlock tier-2: embedding-based semantic conflict detection in pre-edit hook"
+      },
+      {
+        "module": "harvest",
+        "id": "Sylveste-ie6.7",
+        "title": "Transplant Compound's Codex Writer safety logic into Clavain's Codex install path",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Transplant Compound's Codex Writer safety logic into Clavain's Codex install path"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-4b5.15",
+        "title": "Pass@k harness extension + kill-gated test-time-compute scaling spike",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-xka6"
+        ],
+        "notes": "Pass@k harness extension + kill-gated test-time-compute scaling spike"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-4b5.16",
+        "title": "Skaffen compaction verification + context-rot working-set instrumentation",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-6h7x"
+        ],
+        "notes": "Skaffen compaction verification + context-rot working-set instrumentation"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-4b5.14",
+        "title": "ACE coding-skill playbook vs compound-baseline bake-off (measurement-gated spike)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-6h7x"
+        ],
+        "notes": "ACE coding-skill playbook vs compound-baseline bake-off (measurement-gated spike)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-4b5.13",
+        "title": "Trust-card: glanceable per-task human review surface from existing evidence",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Trust-card: glanceable per-task human review surface from existing evidence"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-4b5.12",
+        "title": "Audit-plane correlation layer (deferred, three-feed + consumer gated)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Audit-plane correlation layer (deferred, three-feed + consumer gated)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-4b5.10",
+        "title": "LLM-judge bias doc-hygiene + gate-hardening rider (no new judge epic)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "LLM-judge bias doc-hygiene + gate-hardening rider (no new judge epic)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-4b5.9",
+        "title": "campaign.md route-to-fallback-on-verified-failure (replace blind retry/skip/abort)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-6h7x"
+        ],
+        "notes": "campaign.md route-to-fallback-on-verified-failure (replace blind retry/skip/abort)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-4b5.8",
+        "title": "Conflict-economics telemetry on the parallel dispatcher (Rimsky, child of 3kol)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Conflict-economics telemetry on the parallel dispatcher (Rimsky, child of 3kol)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-4b5.7",
+        "title": "Pre-dispatch parallelizability + cost gate folded into the 3kol Rimsky spec",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Pre-dispatch parallelizability + cost gate folded into the 3kol Rimsky spec"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-4b5.5",
+        "title": "Ground review verdict in concrete pass/fail signal (downgrade unverified 'clean')",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-6h7x"
+        ],
+        "notes": "Ground review verdict in concrete pass/fail signal (downgrade unverified 'clean')"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-4b5.6",
+        "title": "Wire clavain policy engine into a real fail-CLOSED PreToolUse interdiction hook",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-6h7x"
+        ],
+        "notes": "Wire clavain policy engine into a real fail-CLOSED PreToolUse interdiction hook"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-7aj8.9",
+        "title": "interspect skillcal: collector coverage — no_redirect/tokens drop ~97% of rows",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "interspect skillcal: collector coverage — no_redirect/tokens drop ~97% of rows"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-e9c",
+        "title": "Make beads post-merge handler run 'bd import' so git pull auto-syncs Dolt (real fix behind the sync-guard advisory)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Make beads post-merge handler run 'bd import' so git pull auto-syncs Dolt (real fix behind the sync-guard advisory)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-owjn.3",
+        "title": "Extend observation.Snapshot to a true superset (artifacts map + phase-advance history) so ic situation snapshot fully replaces lib-sprint.sh ad-hoc queries",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Extend observation.Snapshot to a true superset (artifacts map + phase-advance history) so ic situation snapshot fully replaces lib-sprint.sh ad-hoc queries"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-22oi.7.7",
+        "title": "Cognitive profile: pattern-awareness SKILL behaviors (Journeys 2/7/21 + harpoon hook)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-22oi.7.4"
+        ],
+        "notes": "Cognitive profile: pattern-awareness SKILL behaviors (Journeys 2/7/21 + harpoon hook)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-22oi.7.4",
+        "title": "Cognitive profile: auraken-profile MCP server (mirror auraken-lens)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-22oi.7.2"
+        ],
+        "notes": "Cognitive profile: auraken-profile MCP server (mirror auraken-lens)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-22oi.7.5",
+        "title": "Cognitive profile: epistemic engine (promotion + half-life decay + harpoon test)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-22oi.7.2"
+        ],
+        "notes": "Cognitive profile: epistemic engine (promotion + half-life decay + harpoon test)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-22oi.7.3",
+        "title": "Cognitive profile: extraction pipeline (trajectory + conversation -> entities)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-22oi.7.2",
+          "sylveste-4wq6"
+        ],
+        "notes": "Cognitive profile: extraction pipeline (trajectory + conversation -> entities)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-ysny",
+        "title": "Skill calibration: signal density too low to trust scoring — gate autonomy on it",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Skill calibration: signal density too low to trust scoring — gate autonomy on it"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-uhjv",
+        "title": "audit.log producer dormant — log-tool-invocation.sh not wired into settings.json",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "audit.log producer dormant — log-tool-invocation.sh not wired into settings.json"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-7aj8",
+        "title": "Interspect skill calibration",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Interspect skill calibration"
+      },
+      {
+        "module": "auraken",
+        "id": "sylveste-0rmf",
+        "title": "Prompt-injection defense for external content (2-of-3 verdict combiner)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Prompt-injection defense for external content (2-of-3 verdict combiner)"
+      },
+      {
+        "module": "interstat+galiana",
+        "id": "sylveste-z7zh",
+        "title": "Landed-work recap report (Goodhart-aware)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Landed-work recap report (Goodhart-aware)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-104h",
+        "title": "Skaffen evidence contract — consume Clavains proven schema (add run_id attribution)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "Sylveste-4b5.16"
+        ],
+        "notes": "Skaffen evidence contract — consume Clavains proven schema (add run_id attribution)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-s01c",
+        "title": "Drop lattice->attp local-path replace (close iv-v5ayb residual)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Drop lattice->attp local-path replace (close iv-v5ayb residual)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-qhn1",
+        "title": "interverse hygiene: root go.work + 3 READMEs + DEPENDENCIES.md + HOOKS-REGISTRY.md",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "interverse hygiene: root go.work + 3 READMEs + DEPENDENCIES.md + HOOKS-REGISTRY.md"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-ungg",
+        "title": "Local plan-phase check in /work + /execute-plan (intercore-independent)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Local plan-phase check in /work + /execute-plan (intercore-independent)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-td2o",
+        "title": "Brainstorm-summary feedforward into plan review (review <- plan,brainstorm)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Brainstorm-summary feedforward into plan review (review <- plan,brainstorm)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-xka6",
+        "title": "Promote B2 complexity routing dispatch-side shadow -> enforce + quality-evidence",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "Sylveste-4b5.18",
+          "Sylveste-4b5.15"
+        ],
+        "notes": "Promote B2 complexity routing dispatch-side shadow -> enforce + quality-evidence"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-lfdy.1",
+        "title": "Wire jetty.io as eval substrate for Auraken voice + behavioral signature scoring",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-22oi.1"
+        ],
+        "notes": "Wire jetty.io as eval substrate for Auraken voice + behavioral signature scoring"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-22oi.3",
+        "title": "Auraken v0.2: GPG signing pipeline for checksums.txt.asc",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Auraken v0.2: GPG signing pipeline for checksums.txt.asc"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-oej5",
+        "title": "F10: auraken-lens Go CLI binary wrapper (cmd/auraken-lens)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-heh8"
+        ],
+        "notes": "F10: auraken-lens Go CLI binary wrapper (cmd/auraken-lens)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-10na",
+        "title": "F9: E2E install smoke + compatibility_evidence transcripts",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-heh8"
+        ],
+        "notes": "F9: E2E install smoke + compatibility_evidence transcripts"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-p6so",
+        "title": "F8: GitHub release auraken-distribution/v0.1.0 + signed checksums + CHANGELOG",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-heh8"
+        ],
+        "notes": "F8: GitHub release auraken-distribution/v0.1.0 + signed checksums + CHANGELOG"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-u74g",
+        "title": "F7: build-dist.sh — deterministic bundle assembly",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-heh8"
+        ],
+        "notes": "F7: build-dist.sh — deterministic bundle assembly"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-m36b",
+        "title": "F6: SKILL.md curation + voice-rubric.md (Mandatory Form / Permitted Variation)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-heh8"
+        ],
+        "notes": "F6: SKILL.md curation + voice-rubric.md (Mandatory Form / Permitted Variation)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-e8te",
+        "title": "F5: INSTALL.md + canonical two-step install path",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-heh8"
+        ],
+        "notes": "F5: INSTALL.md + canonical two-step install path"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-s288",
+        "title": "F4: install.sh — atomic, gated, transmissive close",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-heh8"
+        ],
+        "notes": "F4: install.sh — atomic, gated, transmissive close"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-7g96",
+        "title": "F3: Prebuilt auraken-lens Go binaries for 4 platforms (v0.1.0)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-heh8"
+        ],
+        "notes": "F3: Prebuilt auraken-lens Go binaries for 4 platforms (v0.1.0)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-3v97",
+        "title": "F1: Bundle scaffolding + MANIFEST.yaml v1 schema (auraken-distribution v0.1)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-heh8"
+        ],
+        "notes": "F1: Bundle scaffolding + MANIFEST.yaml v1 schema (auraken-distribution v0.1)"
+      },
+      {
+        "module": "fd",
+        "id": "sylveste-u9cp",
+        "title": "INSTALL.md must lead with encounter framing, not capability enumeration; add substrate-readiness scan",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-e8te"
+        ],
+        "notes": "INSTALL.md must lead with encounter framing, not capability enumeration; add substrate-readiness scan"
+      },
+      {
+        "module": "fd",
+        "id": "sylveste-zjz3",
+        "title": "install.sh step 6 must be a transmissive close, not capability enumeration",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-s288"
+        ],
+        "notes": "install.sh step 6 must be a transmissive close, not capability enumeration"
+      },
+      {
+        "module": "a2a",
+        "id": "sylveste-ewy3.4.1.4",
+        "title": "OAuth2 Resource Indicators authentication on /messages + /tasks",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-ewy3.3"
+        ],
+        "notes": "OAuth2 Resource Indicators authentication on /messages + /tasks"
+      },
+      {
+        "module": "clavain",
+        "id": "sylveste-lfru",
+        "title": "Wire /clavain:ship -> interpath:changelog + interdoc + interwatch:refresh chain",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Wire /clavain:ship -> interpath:changelog + interdoc + interwatch:refresh chain"
+      },
+      {
+        "module": "clavain",
+        "id": "sylveste-clha",
+        "title": "Build /clavain:office-hours adversarial pre-plan gate (gstack import)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Build /clavain:office-hours adversarial pre-plan gate (gstack import)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-ewy3.2.3",
+        "title": "Mythos+1mo decision gate: Langfuse primary vs SQLite + Langfuse shadow",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Mythos+1mo decision gate: Langfuse primary vs SQLite + Langfuse shadow"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-ewy3.2.2",
+        "title": "Langfuse Cloud Hobby setup + 14-day dual-write spike from interspect-evidence",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Langfuse Cloud Hobby setup + 14-day dual-write spike from interspect-evidence"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-ewy3.2.1",
+        "title": "OTEL alignment audit + feature-flagged emission in interspect-evidence.sh",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "Sylveste-4b5.12"
+        ],
+        "notes": "OTEL alignment audit + feature-flagged emission in interspect-evidence.sh"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-ewy3.1.3",
+        "title": "Mythos+1mo decision gate: Temporal full-migration vs. dual-path",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Mythos+1mo decision gate: Temporal full-migration vs. dual-path"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-ewy3.1.2",
+        "title": "Wire first Skaffen test-dispatch as Temporal Workflow + mirror to Intercore event log",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Wire first Skaffen test-dispatch as Temporal Workflow + mirror to Intercore event log"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-ewy3.1.1",
+        "title": "Temporal Cloud dev namespace setup + credentials path",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Temporal Cloud dev namespace setup + credentials path"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-6zhe",
+        "title": "Add Sylveste affected-module build and test runner",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Add Sylveste affected-module build and test runner"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-gd3q",
+        "title": "Repackage Interspect and consolidate evidence telemetry boundaries",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Repackage Interspect and consolidate evidence telemetry boundaries"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-2o0s",
+        "title": "Add flux-review ephemeral read-only mode and cost controls",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Add flux-review ephemeral read-only mode and cost controls"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-z55b",
+        "title": "Refactor Clavain SessionStart into cached read model plus hook health ledger",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Refactor Clavain SessionStart into cached read model plus hook health ledger"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-7zw2",
+        "title": "Implement generated-agent retention, pack-scoped loading, and stale index refresh",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Implement generated-agent retention, pack-scoped loading, and stale index refresh"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-xoki.3",
+        "title": "Plugin and skill architecture deprecation plan",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Plugin and skill architecture deprecation plan"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-xoki.2",
+        "title": "Agent evidence receipts for Codex and Claude Code",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Agent evidence receipts for Codex and Claude Code"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-xoki.1",
+        "title": "Codex discovery hygiene: fix stale skill/frontmatter and cache noise",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Codex discovery hygiene: fix stale skill/frontmatter and cache noise"
+      },
+      {
+        "module": "spike-pivot",
+        "id": "Sylveste-0gi.2.7",
+        "title": "RunPod H200 rental for DeepSeek V4 baseline logit capture (Day-3 unblock)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "RunPod H200 rental for DeepSeek V4 baseline logit capture (Day-3 unblock)"
+      },
+      {
+        "module": "spike",
+        "id": "Sylveste-0gi.2",
+        "title": "DeepSeek V4 → flash-moe 5-day feasibility spike (C-prime)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "DeepSeek V4 → flash-moe 5-day feasibility spike (C-prime)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-00qu",
+        "title": "beads: 3 UX/correctness issues (bd dolt push help-on-no-remote, missing embedded-DB bootstrap from issues.jsonl, persistent 0755 permission warning)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "beads: 3 UX/correctness issues (bd dolt push help-on-no-remote, missing embedded-DB bootstrap from issues.jsonl, persistent 0755 permission warning)"
+      },
+      {
+        "module": "interfer+interflux",
+        "id": "Sylveste-k8c",
+        "title": "Local inference backend for flux-review agents — server-mode bridge",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "Sylveste-bvh"
+        ],
+        "notes": "Local inference backend for flux-review agents — server-mode bridge"
+      },
+      {
+        "module": "routing",
+        "id": "Sylveste-2bg",
+        "title": "Re-measure heuristic coverage after agent-roles.yaml extension",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "Sylveste-cs2"
+        ],
+        "notes": "Re-measure heuristic coverage after agent-roles.yaml extension"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-3xl3.1.25",
+        "title": "F4.7: Pre-allow Bash mkdir/Write/Read for teammates in flux-explore --teams",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "F4.7: Pre-allow Bash mkdir/Write/Read for teammates in flux-explore --teams"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-3xl3.1.24",
+        "title": "F4.6: Inbox-as-transcript adapter for team_synthesize.py finalize",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "F4.6: Inbox-as-transcript adapter for team_synthesize.py finalize"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-3xl3.1.23",
+        "title": "F5.3: Resolve teammate session UUIDs from team config + project session JSONLs",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "F5.3: Resolve teammate session UUIDs from team config + project session JSONLs"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-mj11.5",
+        "title": "Break Synaxis cadence + chain-of-custody schema + axis-set publication",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Break Synaxis cadence + chain-of-custody schema + axis-set publication"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-mj11.6",
+        "title": "Dormancy/degradation rubric, Bauschinger-positive demotion, tarbiya pathway, non-conformance disposition",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Dormancy/degradation rubric, Bauschinger-positive demotion, tarbiya pathway, non-conformance disposition"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-mj11.4",
+        "title": "Break invariant tuple schema and per-subsystem calibration",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Break invariant tuple schema and per-subsystem calibration"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-mj11.3",
+        "title": "Interspect substrate-independence and suhba-window classification per subsystem",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Interspect substrate-independence and suhba-window classification per subsystem"
+      },
+      {
+        "module": "microrouter",
+        "id": "sylveste-5p7s",
+        "title": "F2: D2 heuristic-baseline measurement — sibling to .19.9, parallel-runnable",
+        "phase": "next",
+        "priority": "P2",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "F2: D2 heuristic-baseline measurement — sibling to .19.9, parallel-runnable"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-3xl3.1.19",
+        "title": "F6.2: Run live A/B benchmark on flux-explore-teams-brainstorm-{adjacent,distant}.json corpus",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "F6.2: Run live A/B benchmark on flux-explore-teams-brainstorm-{adjacent,distant}.json corpus"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-3xl3.7",
+        "title": "flux-explore --teams Approach 2: target-mode review-debate",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-3xl3.1"
+        ],
+        "notes": "flux-explore --teams Approach 2: target-mode review-debate"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-3xl3.4",
+        "title": "Wire TeammateIdle/TaskCreated/TaskCompleted hooks into Interspect evidence pipeline",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Wire TeammateIdle/TaskCreated/TaskCompleted hooks into Interspect evidence pipeline"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-3xl3.2",
+        "title": "flux-drive convergent finding triangulation via agent teams",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "flux-drive convergent finding triangulation via agent teams"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-3xl3.3",
+        "title": "/clavain:debate + intermonk:dialectic agent-teams upgrade",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "/clavain:debate + intermonk:dialectic agent-teams upgrade"
+      },
+      {
+        "module": "interspect",
+        "id": "sylveste-sfhq",
+        "title": "Telemetry fusion: wire tool-time stats into interspect evidence",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Telemetry fusion: wire tool-time stats into interspect evidence"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-05rf",
+        "title": "Auraken lens cleanup: cross-referencing pairs that may be authoring drift not distinct lenses",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Auraken lens cleanup: cross-referencing pairs that may be authoring drift not distinct lenses"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-lf3b",
+        "title": "Rename fd-agent personas with misleading lexical-prefix collisions",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Rename fd-agent personas with misleading lexical-prefix collisions"
+      },
+      {
+        "module": "interfer",
+        "id": "Sylveste-bov",
+        "title": "flash-moe decode regression — 5 tok/s actual vs 12.9 tok/s spec",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "flash-moe decode regression — 5 tok/s actual vs 12.9 tok/s spec"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.35.6",
+        "title": "BP-C2.B: run_uuid quire-mark + decisions.log per-run",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "BP-C2.B: run_uuid quire-mark + decisions.log per-run"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.32.7",
+        "title": "BP-C1.C: extract scripts/_fluxbench_score.py from fluxbench-score.sh heredoc (180 lines)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "BP-C1.C: extract scripts/_fluxbench_score.py from fluxbench-score.sh heredoc (180 lines)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-a4oj.9",
+        "title": "Phase 2 — Dirty-bit and routing replacement infrastructure (S-difficulty bundle)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Phase 2 — Dirty-bit and routing replacement infrastructure (S-difficulty bundle)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-a4oj",
+        "title": "Multi-axis improvement: usability, token efficiency, ML-routing replacement (flux-review 2026-05-04)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "Sylveste-4b5.14"
+        ],
+        "notes": "Multi-axis improvement: usability, token efficiency, ML-routing replacement (flux-review 2026-05-04)"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-wyoi",
+        "title": "Brainstorm-to-roadmap lift discipline — checklist step in /interpath:roadmap",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Brainstorm-to-roadmap lift discipline — checklist step in /interpath:roadmap"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.37",
+        "title": "Holdout Register — name the ground-truth source for every calibration loop",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "Sylveste-4b5.1"
+        ],
+        "notes": "Holdout Register — name the ground-truth source for every calibration loop"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-lrnk",
+        "title": "Editor-of-record protocol for shared design-doc sections + n6zw close-predicate",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Editor-of-record protocol for shared design-doc sections + n6zw close-predicate"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.35",
+        "title": "BP-C2: explicit dispatch state machine + VerificationStep primitive + run_uuid + decisions.log",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "Sylveste-4b5.9",
+          "Sylveste-4b5.12",
+          "Sylveste-4b5.5",
+          "Sylveste-4b5.13"
+        ],
+        "notes": "BP-C2: explicit dispatch state machine + VerificationStep primitive + run_uuid + decisions.log"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.33",
+        "title": "BP-C3: sanitize_untrusted.py fuzz tests + TrustedContent NewType — full 4-channel integration",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "BP-C3: sanitize_untrusted.py fuzz tests + TrustedContent NewType — full 4-channel integration"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.32",
+        "title": "BP-C1: lib_registry.py + registry-write consolidation (5 atomic-mutate sites + scoring algorithm extraction)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "BP-C1: lib_registry.py + registry-write consolidation (5 atomic-mutate sites + scoring algorithm extraction)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-o8wo",
+        "title": "Fix subagent Write permission for flux-gen-specs and docs/research/flux-* directories",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Fix subagent Write permission for flux-gen-specs and docs/research/flux-* directories"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-wrz",
+        "title": "Clavain: restore README count line + publish project-onboard update (0.6.252)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Clavain: restore README count line + publish project-onboard update (0.6.252)"
+      },
+      {
+        "module": "microrouter",
+        "id": "sylveste-s3z6.19.6",
+        "title": "Privacy-routing extension — sensitive tasks always engage router",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-s3z6.19.5"
+        ],
+        "notes": "Privacy-routing extension — sensitive tasks always engage router"
+      },
+      {
+        "module": "microrouter",
+        "id": "sylveste-s3z6.19.5",
+        "title": "Resolver integration in Clavain — wire into routing.yaml",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-s3z6.19.1"
+        ],
+        "notes": "Resolver integration in Clavain — wire into routing.yaml"
+      },
+      {
+        "module": "v6-candidate",
+        "id": "sylveste-xq0t",
+        "title": "Per-tier demotion latency bounds",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Per-tier demotion latency bounds"
+      },
+      {
+        "module": "v6-candidate",
+        "id": "sylveste-aon0",
+        "title": "Cross-source evidence independence test",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Cross-source evidence independence test"
+      },
+      {
+        "module": "v6-candidate",
+        "id": "sylveste-2h3o",
+        "title": "Phase 3-4 bootstrap spec — initial governance policy + handoff criteria",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Phase 3-4 bootstrap spec — initial governance policy + handoff criteria"
+      },
+      {
+        "module": "v6-candidate",
+        "id": "sylveste-9um7",
+        "title": "Routing-decision evidence schema for Ockham + Clavain + intercept",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Routing-decision evidence schema for Ockham + Clavain + intercept"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-mj11.2",
+        "title": "Tier-weight aggregation specification + conflict-resolution rule",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Tier-weight aggregation specification + conflict-resolution rule"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-mj11.1",
+        "title": "Hallmark log: immutable advancement_events table for trust-tier transitions",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Hallmark log: immutable advancement_events table for trust-tier transitions"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-yxk8",
+        "title": "F6: North Star integration + observation methodology + Goodhart breaker",
+        "phase": "next",
+        "priority": "P2",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-3z91",
+          "sylveste-8r5h"
+        ],
+        "notes": "F6: North Star integration + observation methodology + Goodhart breaker"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-j7gy",
+        "title": "F5: Plugin manifest annotations + 5-plugin reference adoption",
+        "phase": "next",
+        "priority": "P2",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-mblb",
+          "sylveste-8r5h"
+        ],
+        "notes": "F5: Plugin manifest annotations + 5-plugin reference adoption"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-3z91",
+        "title": "F4: interspect activation CLI (per-subsystem + fleet rollup)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-islh",
+          "sylveste-8r5h"
+        ],
+        "notes": "F4: interspect activation CLI (per-subsystem + fleet rollup)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-islh",
+        "title": "F3: Interspect activation aggregator (race-fixed cursor + dedup)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-8r5h",
+          "sylveste-jdnh"
+        ],
+        "notes": "F3: Interspect activation aggregator (race-fixed cursor + dedup)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-mblb",
+        "title": "F2: Subsystem emit helper (Go + bash) with durable session sentinel",
+        "phase": "next",
+        "priority": "P2",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-8r5h",
+          "sylveste-jdnh"
+        ],
+        "notes": "F2: Subsystem emit helper (Go + bash) with durable session sentinel"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-lwp7",
+        "title": "lattice: apply_lifecycle_transition mutates et.families in registered EntityType",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "lattice: apply_lifecycle_transition mutates et.families in registered EntityType"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-3xgz",
+        "title": "Fresh-session remeasure: validate ~1,482b skill_listing reduction from sylveste-zppj",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Fresh-session remeasure: validate ~1,482b skill_listing reduction from sylveste-zppj"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-ukd3",
+        "title": "lattice-web V0 — static browse + search at interverse/lattice/web/",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-r3jf"
+        ],
+        "notes": "lattice-web V0 — static browse + search at interverse/lattice/web/"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-w8zv",
+        "title": "Rename github upstream mistakeknot/interweave → mistakeknot/lattice + update go.mod",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Rename github upstream mistakeknot/interweave → mistakeknot/lattice + update go.mod"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-wdf2.2",
+        "title": "L2: PreToolUse hook surfaces drift on doc access; auto-fire on Certain",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "L2: PreToolUse hook surfaces drift on doc access; auto-fire on Certain"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-wdf2",
+        "title": "Doc monitoring automation (replaces interscout shape)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Doc monitoring automation (replaces interscout shape)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-129h",
+        "title": "Cache-corrected cost-per-landable-change as second-line north-star",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Cache-corrected cost-per-landable-change as second-line north-star"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-5lla",
+        "title": "Load-path independence audit of the evidence-infra ring",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Load-path independence audit of the evidence-infra ring"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-v3ck",
+        "title": "Demotion-rehearsal as M3+ promotion precondition",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Demotion-rehearsal as M3+ promotion precondition"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-4rwh",
+        "title": "Add Break stage to trust lifecycle (Earn → Compound → Break → Epoch → Demote)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Add Break stage to trust lifecycle (Earn → Compound → Break → Epoch → Demote)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-fd7x.7",
+        "title": "Resolve intersite plugin repository remote/publish target",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Resolve intersite plugin repository remote/publish target"
+      },
+      {
+        "module": "interfer",
+        "id": "Sylveste-ep8",
+        "title": "Evaluate Qwen3.6-27B-OptiQ-4bit (released 2026-04-25)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "Sylveste-xzw"
+        ],
+        "notes": "Evaluate Qwen3.6-27B-OptiQ-4bit (released 2026-04-25)"
+      },
+      {
+        "module": "interfer",
+        "id": "Sylveste-6ru",
+        "title": "Qwen3.6-35B-A3B quantization sweep (DWQ vs nvfp4 vs OptiQ vs plain)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "Sylveste-xzw"
+        ],
+        "notes": "Qwen3.6-35B-A3B quantization sweep (DWQ vs nvfp4 vs OptiQ vs plain)"
+      },
+      {
+        "module": "interfer",
+        "id": "Sylveste-0gi",
+        "title": "DeepSeek V4 Flash on flash-moe — port effort vs wait-for-hardware decision",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "DeepSeek V4 Flash on flash-moe — port effort vs wait-for-hardware decision"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-4wq6",
+        "title": "Extend auraken-lens trajectory schema: capture lenses_offered + user question choice (training signal)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-khb8"
+        ],
+        "notes": "Extend auraken-lens trajectory schema: capture lenses_offered + user question choice (training signal)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-g939",
+        "title": "F6b: flux-drive triage backend swap + A/B execution + ship decision",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-71nz",
+          "sylveste-r3jf",
+          "sylveste-2n8i"
+        ],
+        "notes": "F6b: flux-drive triage backend swap + A/B execution + ship decision"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-1j30",
+        "title": "F7: interlens MCP adapter — swap JSON backend to ontology-queries",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-b1ha",
+          "sylveste-71nz"
+        ],
+        "notes": "F7: interlens MCP adapter — swap JSON backend to ontology-queries"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-dsbl",
+        "title": "F3: Schema + DDL migration 001 — 7-entity ontology with all G3-G9 fields locked",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-r3jf",
+          "sylveste-b1ha",
+          "sylveste-j5vi",
+          "sylveste-4uhk"
+        ],
+        "notes": "F3: Schema + DDL migration 001 — 7-entity ontology with all G3-G9 fields locked"
+      },
+      {
+        "module": "interfer 2ss",
+        "id": "Sylveste-r8g",
+        "title": "Add SWE-bench Lite runner to code_correctness harness",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "Sylveste-b7j"
+        ],
+        "notes": "Add SWE-bench Lite runner to code_correctness harness"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-b1ha",
+        "title": "Persona/lens database: unify fd-agents + Auraken lenses",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Persona/lens database: unify fd-agents + Auraken lenses"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-301b",
+        "title": "Diagnose interstat tool_selection_events ↔ agent_runs session_id join gap",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Diagnose interstat tool_selection_events ↔ agent_runs session_id join gap"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-t5x4",
+        "title": "auraken-thinker MCP server (sibling to auraken-lens)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-am7w",
+          "sylveste-2xzz"
+        ],
+        "notes": "auraken-thinker MCP server (sibling to auraken-lens)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-am7w",
+        "title": "Meadows profile (validation anchor — 12 leverage points rediscovery test)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-1nvc",
+          "sylveste-2xzz"
+        ],
+        "notes": "Meadows profile (validation anchor — 12 leverage points rediscovery test)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-f314",
+        "title": "Appleton profile (structure-rich corpus test)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-2xzz",
+          "sylveste-am7w",
+          "sylveste-1nvc"
+        ],
+        "notes": "Appleton profile (structure-rich corpus test)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-1nvc",
+        "title": "Generic thinker-profile extraction pipeline",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-2xzz"
+        ],
+        "notes": "Generic thinker-profile extraction pipeline"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-2xzz",
+        "title": "Thinker-profile schema v1 (YAML + validation harness)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Thinker-profile schema v1 (YAML + validation harness)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-i0px",
+        "title": "Auraken thinker-profile system (proprietary reasoning moat)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-1h0b",
+          "sylveste-52ys",
+          "sylveste-9prl",
+          "sylveste-8g69",
+          "sylveste-f314",
+          "sylveste-am7w",
+          "sylveste-2xzz",
+          "sylveste-22oi",
+          "sylveste-bsh1",
+          "sylveste-1nvc",
+          "sylveste-t5x4"
+        ],
+        "notes": "Auraken thinker-profile system (proprietary reasoning moat)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-dz94",
+        "title": "Run test-conversations.md acceptance on Claude-family models (Opus + Haiku)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-khb8"
+        ],
+        "notes": "Run test-conversations.md acceptance on Claude-family models (Opus + Haiku)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-byw",
+        "title": "interhelm/intersight: resolve dual tracking between umbrella and standalone repos",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "interhelm/intersight: resolve dual tracking between umbrella and standalone repos"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-pexq",
+        "title": "Audit Python MCP servers for lazy top-level imports",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-116u"
+        ],
+        "notes": "Audit Python MCP servers for lazy top-level imports"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-ung7",
+        "title": "Reconsider sylveste-7505 consolidation given spike C findings (cold-start math doesn't favor it)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-116u"
+        ],
+        "notes": "Reconsider sylveste-7505 consolidation given spike C findings (cold-start math doesn't favor it)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-jum2",
+        "title": "Precompile interrank TypeScript at publish time (drop tsx runtime)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-116u"
+        ],
+        "notes": "Precompile interrank TypeScript at publish time (drop tsx runtime)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-ttwz",
+        "title": "Triage Python MCP servers for Go port candidates (hot-path first)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-116u"
+        ],
+        "notes": "Triage Python MCP servers for Go port candidates (hot-path first)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-06yf",
+        "title": "Refactor interfer onto MCP SDK or scope out of consolidation (prereq for sylveste-7505)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Refactor interfer onto MCP SDK or scope out of consolidation (prereq for sylveste-7505)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-35x5",
+        "title": "Migrate interlens to high-level MCP TS SDK (prereq for sylveste-7505)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Migrate interlens to high-level MCP TS SDK (prereq for sylveste-7505)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-x6e4",
+        "title": "Multi-mcpServers capability spike (prereq for sylveste-7505)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Multi-mcpServers capability spike (prereq for sylveste-7505)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-5jn8",
+        "title": "Auraken lens_select latency: 12-20s per call is real UX cost (dogfood finding)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Auraken lens_select latency: 12-20s per call is real UX cost (dogfood finding)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-1mb8",
+        "title": "Auraken-Hermes: cross-provider validation (does selector transfer beyond Claude?)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Auraken-Hermes: cross-provider validation (does selector transfer beyond Claude?)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-4li0",
+        "title": "interop: daemon adapter construction from config",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "interop: daemon adapter construction from config"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-i8gp",
+        "title": "Evidence pipeline wiring — activate sylveste-xcn4 and close the flywheel",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-5qv9",
+          "sylveste-xcn4"
+        ],
+        "notes": "Evidence pipeline wiring — activate sylveste-xcn4 and close the flywheel"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-uzpo",
+        "title": "Interface evidence instrumentation — 5 cross-subsystem signals",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Interface evidence instrumentation — 5 cross-subsystem signals"
+      },
+      {
+        "module": "interfer",
+        "id": "Sylveste-2ss",
+        "title": "Flash-MoE holistic benchmark suite — quality, latency, memory, reliability",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "Sylveste-k8c",
+          "Sylveste-bov"
+        ],
+        "notes": "Flash-MoE holistic benchmark suite — quality, latency, memory, reliability"
+      },
+      {
+        "module": "interfer",
+        "id": "Sylveste-wfz",
+        "title": "Fix test_polar_transform_range TurboQuant test failure",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Fix test_polar_transform_range TurboQuant test failure"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-v4t2",
+        "title": "Meadowsyn experiment suite (jpum successor)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Meadowsyn experiment suite (jpum successor)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-fa1m",
+        "title": "Gmail purchase import pipeline (fbz successor)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Gmail purchase import pipeline (fbz successor)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-lon1",
+        "title": "Cross-model dispatch scoring + integration (9lp.9 successor)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Cross-model dispatch scoring + integration (9lp.9 successor)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-lny4",
+        "title": "Self-dispatch loop for AI factory (ysxe.3 successor)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Self-dispatch loop for AI factory (ysxe.3 successor)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-jqxf",
+        "title": "AI Factory Wave 1 foundation (ysxe successor)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "AI Factory Wave 1 foundation (ysxe successor)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-u28h",
+        "title": "CPVO + DWSQ domain-general north star metrics (rsj.4 successor)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "CPVO + DWSQ domain-general north star metrics (rsj.4 successor)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-39p5",
+        "title": "F5: TypeScript plugin adapters (interfluence,interlens,interrank,tuivision)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-6m1k",
+          "sylveste-7505"
+        ],
+        "notes": "F5: TypeScript plugin adapters (interfluence,interlens,interrank,tuivision)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-6m1k",
+        "title": "F3: interserve-ts adapter framework",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-7505",
+          "sylveste-h4mw"
+        ],
+        "notes": "F3: interserve-ts adapter framework"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-lbvq",
+        "title": "F4: Python plugin adapters (intercache,interdeep,interfer,interject,intersearch,interseed)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-amcz",
+          "sylveste-7505"
+        ],
+        "notes": "F4: Python plugin adapters (intercache,interdeep,interfer,interject,intersearch,interseed)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-7505",
+        "title": "Consolidated interverse MCP server",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-x6e4",
+          "sylveste-35x5",
+          "sylveste-06yf"
+        ],
+        "notes": "Consolidated interverse MCP server"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-fyo3.6",
+        "title": "P2: Hard budget enforcement mode — test and enable blocking behavior",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "P2: Hard budget enforcement mode — test and enable blocking behavior"
+      },
+      {
+        "module": "interfer",
+        "id": "sylveste-yfot",
+        "title": "Benchmark speculative decoding with 9B draft model",
+        "phase": "next",
+        "priority": "P2",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Benchmark speculative decoding with 9B draft model"
+      },
+      {
+        "module": "interfer",
+        "id": "sylveste-dczo",
+        "title": "Promote Track B5 to enforce mode",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-35tf"
+        ],
+        "notes": "Promote Track B5 to enforce mode"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-j0yv",
+        "title": "F5.5: Shared resolution primitives",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-5b7"
+        ],
+        "notes": "F5.5: Shared resolution primitives"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-8ucm",
+        "title": "F5.3: Core query templates (4 pure queries)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-5b7"
+        ],
+        "notes": "F5.3: Core query templates (4 pure queries)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-34r2",
+        "title": "F5.2: Go-Python persistent worker bridge",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-5b7"
+        ],
+        "notes": "F5.2: Go-Python persistent worker bridge"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-tfj7",
+        "title": "F7: Challenger slot mechanism for unqualified candidates",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-5bwp"
+        ],
+        "notes": "F7: Challenger slot mechanism for unqualified candidates"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-qroh",
+        "title": "F6: interrank TASK_DOMAIN_MAP FluxBench integration",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-5gr4"
+        ],
+        "notes": "F6: interrank TASK_DOMAIN_MAP FluxBench integration"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-usvf",
+        "title": "F5: Proactive model surfacing — SessionStart + weekly schedule",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-5bwp"
+        ],
+        "notes": "F5: Proactive model surfacing — SessionStart + weekly schedule"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-ye7y",
+        "title": "F4: Drift detection — sample-based + version-triggered",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-5bwp"
+        ],
+        "notes": "F4: Drift detection — sample-based + version-triggered"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-cnxf",
+        "title": "Redesign gsvdotcom: ACRNM-inspired technical document aesthetic",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Redesign gsvdotcom: ACRNM-inspired technical document aesthetic"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-vsi4",
+        "title": "F6: MCP server + Claude Code plugin",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-bcok"
+        ],
+        "notes": "F6: MCP server + Claude Code plugin"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-fij2",
+        "title": "F5: Local filesystem adapter — fsnotify, SHA-256 change detection",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-bcok"
+        ],
+        "notes": "F5: Local filesystem adapter — fsnotify, SHA-256 change detection"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-xmav",
+        "title": "F4: Notion adapter — pages, databases, webhooks (port from interkasten)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-bcok"
+        ],
+        "notes": "F4: Notion adapter — pages, databases, webhooks (port from interkasten)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-xfsr",
+        "title": "F3: GitHub adapter — App webhooks, Issues, PRs, repo files",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-bcok"
+        ],
+        "notes": "F3: GitHub adapter — App webhooks, Issues, PRs, repo files"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-9g6v",
+        "title": "F2: Beads adapter — bidirectional bd CLI sync",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-bcok"
+        ],
+        "notes": "F2: Beads adapter — bidirectional bd CLI sync"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-2131",
+        "title": "F1: Core daemon + event bus (SyncJournal, CollisionWindow, AncestorStore)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-bcok"
+        ],
+        "notes": "F1: Core daemon + event bus (SyncJournal, CollisionWindow, AncestorStore)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-benl.11",
+        "title": "Decommission Auraken Python runtime",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Decommission Auraken Python runtime"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-nr6x.5",
+        "title": "L5: Skaffen integration — sovereign agent lifecycle",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "L5: Skaffen integration — sovereign agent lifecycle"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-nr6x.4",
+        "title": "L4: Signal-native tool approval transport",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "L4: Signal-native tool approval transport"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-5boi",
+        "title": "Signal command: log (recent forge sessions)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Signal command: log (recent forge sessions)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-5hx7",
+        "title": "Signal command: diff (re-show pending changes)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Signal command: diff (re-show pending changes)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-dd6t",
+        "title": "Rate limiting for forge code commands",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Rate limiting for forge code commands"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-xspv",
+        "title": "Auto-revert timeout for pending forge code changes",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Auto-revert timeout for pending forge code changes"
+      },
+      {
+        "module": "epic",
+        "id": "sylveste-bcok",
+        "title": "interop: Notion + Auraken + Clavain + GitHub integration bridge",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "interop: Notion + Auraken + Clavain + GitHub integration bridge"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-llen",
+        "title": "Strengthen natural-language feedback loop for self-improvement",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Strengthen natural-language feedback loop for self-improvement"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-xd0n",
+        "title": "Forge mode on Signal transport",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Forge mode on Signal transport"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-gfp2",
+        "title": "Style mirroring for early conversations (pre-fingerprint)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Style mirroring for early conversations (pre-fingerprint)"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.22",
+        "title": "P2: Trust model diagnostics — explain low scores and feed back into prompt tuning",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "P2: Trust model diagnostics — explain low scores and feed back into prompt tuning"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.21",
+        "title": "P2: Typed agent-state log — JSONL per agent replacing in-prompt state tracking",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "P2: Typed agent-state log — JSONL per agent replacing in-prompt state tracking"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.20",
+        "title": "P2: Embedding-based dedup pass — cosine similarity on finding titles for conceptual duplicates",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "P2: Embedding-based dedup pass — cosine similarity on finding titles for conceptual duplicates"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.18",
+        "title": "P2: Evaluation rubrics — track finding recall, precision, coverage over time",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "P2: Evaluation rubrics — track finding recall, precision, coverage over time"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.19",
+        "title": "P2: Difficulty-aware slot ceiling — replace static formula with content-signal estimator",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-9lp.8"
+        ],
+        "notes": "P2: Difficulty-aware slot ceiling — replace static formula with content-signal estimator"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.17",
+        "title": "P2: Passage-level citation in research synthesis — attribute claims to source passages, not agents",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "P2: Passage-level citation in research synthesis — attribute claims to source passages, not agents"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.15",
+        "title": "P2: Structured disagreement as first-class output — disagreement_profile in findings schema",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "P2: Structured disagreement as first-class output — disagreement_profile in findings schema"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-q2k",
+        "title": "F6: Autonomy ratchet state machine",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-8em"
+        ],
+        "notes": "F6: Autonomy ratchet state machine"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-usj",
+        "title": "F5: Tier 1 INFORM signals + pleasure signals",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-8em"
+        ],
+        "notes": "F5: Tier 1 INFORM signals + pleasure signals"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7.14",
+        "title": "Fix alternate screen buffer detection for cursor position",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Fix alternate screen buffer detection for cursor position"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7.10",
+        "title": "Add ROI (region-of-interest) encoding — high fidelity for active regions only",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Add ROI (region-of-interest) encoding — high fidelity for active regions only"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7",
+        "title": "Tuivision: token-efficient terminal state encoding",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Tuivision: token-efficient terminal state encoding"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-18a.12",
+        "title": "MCP HTTP/SSE transport for Skaffen",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "MCP HTTP/SSE transport for Skaffen"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-18a.10",
+        "title": "Two-stage LLM bash safety classifier for Skaffen trust evaluator",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Two-stage LLM bash safety classifier for Skaffen trust evaluator"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-18a.11",
+        "title": "Persistent agent memory system for Skaffen",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Persistent agent memory system for Skaffen"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-18a.5",
+        "title": "Permission bubble mode for nested Skaffen agent chains",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-18a.6"
+        ],
+        "notes": "Permission bubble mode for nested Skaffen agent chains"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-18a.3",
+        "title": "Fork subagent cache optimization for parallel OODARC spawns",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Fork subagent cache optimization for parallel OODARC spawns"
+      },
+      {
+        "module": "auraken",
+        "id": "sylveste-2l1.5",
+        "title": "Extract REDDIT_threaded sample (5K posts) for coverage index",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Extract REDDIT_threaded sample (5K posts) for coverage index"
+      },
+      {
+        "module": "auraken",
+        "id": "sylveste-2l1.6",
+        "title": "AITA near-miss density analysis (270K moral dilemmas)",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "AITA near-miss density analysis (270K moral dilemmas)"
+      },
+      {
+        "module": "auraken",
+        "id": "sylveste-2l1.4",
+        "title": "Build anchor scenario regression suite from daily_dilemmas",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Build anchor scenario regression suite from daily_dilemmas"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-rom",
+        "title": "Full pipeline enforcement: MDX stripping, HMAC webhook, preview gating",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Full pipeline enforcement: MDX stripping, HMAC webhook, preview gating"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-cqa",
+        "title": "Port interblog content collections to /blog/ with one-way sync",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Port interblog content collections to /blog/ with one-way sync"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-wlk",
+        "title": "Publish seed experiments after voice review",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Publish seed experiments after voice review"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-nyx",
+        "title": "Hidden /about page with mission/vision from GSV identity repo",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Hidden /about page with mission/vision from GSV identity repo"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-pf4",
+        "title": "intersite-blog: blog fold-in + full pipeline enforcement",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "intersite-blog: blog fold-in + full pipeline enforcement"
+      },
+      {
+        "module": "auraken",
+        "id": "sylveste-muf",
+        "title": "Research: ambient recommendation UX — window shopping vs. over-indexed personalization",
+        "phase": "next",
+        "priority": "P2",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Research: ambient recommendation UX — window shopping vs. over-indexed personalization"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-rsj.8",
+        "title": "Stigmergic coordination substrate — pheromone fields with decay on shared documents",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Stigmergic coordination substrate — pheromone fields with decay on shared documents"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-rsj.3.14",
+        "title": "Run BALROG TextWorld baseline: raw model vs Skaffen-orchestrated progression comparison",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Run BALROG TextWorld baseline: raw model vs Skaffen-orchestrated progression comparison"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-dvu",
+        "title": "Unified user identity: composite identity table",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Unified user identity: composite identity table"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-rsj.3.5",
+        "title": "Evaluate Agentica SDK as complementary agent framework — type-safe multi-agent with stateful REPL",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Evaluate Agentica SDK as complementary agent framework — type-safe multi-agent with stateful REPL"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-rsj.3",
+        "title": "Roguelike-Inspired Agent Architecture — structural patterns from NLE/BALROG/Arcgentica for Garden Salon",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Roguelike-Inspired Agent Architecture — structural patterns from NLE/BALROG/Arcgentica for Garden Salon"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-pfi",
+        "title": "F5: Signal feeds + graduation workflow",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-em9"
+        ],
+        "notes": "F5: Signal feeds + graduation workflow"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-m2p",
+        "title": "F4: Garden Salon agent bridge for interseed",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-em9"
+        ],
+        "notes": "F4: Garden Salon agent bridge for interseed"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-ya2",
+        "title": "F2: Auraken idea capture via /idea command",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-ec1"
+        ],
+        "notes": "F2: Auraken idea capture via /idea command"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-rsj",
+        "title": "EPIC: Sylveste SOTA — Garden Salon Architecture",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "EPIC: Sylveste SOTA — Garden Salon Architecture"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-yrc",
+        "title": "clavain-cli not on PATH after monorepo clone",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "clavain-cli not on PATH after monorepo clone"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-qbv",
+        "title": "Experiment: LayerSkip / self-speculative early exit",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Experiment: LayerSkip / self-speculative early exit"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-m71",
+        "title": "Publish Pareto frontier analysis: speed vs quality across local models",
+        "phase": "next",
+        "priority": "P2",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-4l2",
+          "sylveste-bpg",
+          "sylveste-8t0",
+          "sylveste-8v3",
+          "Sylveste-4b5.19",
+          "sylveste-36m",
+          "sylveste-uln"
+        ],
+        "notes": "Publish Pareto frontier analysis: speed vs quality across local models"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-0h8",
+        "title": "Competitive Landscape: Close Clavain routing gaps vs LiteLLM/OpenRouter",
+        "phase": "next",
+        "priority": "P2",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Competitive Landscape: Close Clavain routing gaps vs LiteLLM/OpenRouter"
       }
     ],
     "later": [
       {
         "module": "sylveste",
-        "id": "Revel-xhd",
-        "title": "Harden Claude review schema compliance for large evidence packages",
+        "id": "Sylveste-8rpw",
+        "title": "zklw: delete the phantom ~/projects/Demarch tree (needs mk's go)",
         "phase": "later",
         "priority": "P3",
-        "status": "in_progress",
+        "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Harden Claude review schema compliance for large evidence packages"
+        "notes": "zklw: delete the phantom ~/projects/Demarch tree (needs mk's go)"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-75ca",
-        "title": "Posture formula separation — Thoroughness/Diligence and Improvisation/Creativity collapse",
+        "id": "Sylveste-lsh8",
+        "title": "Post the drafted bd export -o upstream report to gastownhall/beads",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Posture formula separation — Thoroughness/Diligence and Improvisation/Creativity collapse"
+        "notes": "Post the drafted bd export -o upstream report to gastownhall/beads"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-yaxt",
-        "title": "AngerThreshold recovery mechanic — Solo recovery evolution event",
+        "id": "sylveste-esjb",
+        "title": "Bootstrap or retire the 16 beads DBs with no local database",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "AngerThreshold recovery mechanic — Solo recovery evolution event"
-      },
-      {
-        "module": "Theme",
-        "id": "shadow-work-2q9g",
-        "title": "Tooling & Infrastructure — Dev tools, CI, campaign runner, diagnostics",
-        "phase": "later",
-        "priority": "P3",
-        "status": "open",
-        "source": "beads",
-        "source_file": "beads",
-        "blocked_by": [],
-        "notes": "Tooling & Infrastructure — Dev tools, CI, campaign runner, diagnostics"
-      },
-      {
-        "module": "Theme",
-        "id": "shadow-work-c937",
-        "title": "Technical Debt & Performance — Refactoring, tick perf, simplification",
-        "phase": "later",
-        "priority": "P3",
-        "status": "open",
-        "source": "beads",
-        "source_file": "beads",
-        "blocked_by": [],
-        "notes": "Technical Debt & Performance — Refactoring, tick perf, simplification"
+        "notes": "Bootstrap or retire the 16 beads DBs with no local database"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-bhca",
-        "title": "Missing cross-category interaction pairs",
+        "id": "Sylveste-ns0m",
+        "title": "dotfiles .claude/CLAUDE.md — last file of the retired root tree, carved out for a sibling session",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Missing cross-category interaction pairs"
+        "notes": "dotfiles .claude/CLAUDE.md — last file of the retired root tree, carved out for a sibling session"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-ohhv",
-        "title": "Base simulation wire: Optimism → perceived-risk bias",
+        "id": "Sylveste-e7m3",
+        "title": "sylveste-vision.md links to docs/sylveste-reference.md, which does not exist",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Base simulation wire: Optimism → perceived-risk bias"
+        "notes": "sylveste-vision.md links to docs/sylveste-reference.md, which does not exist"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-u53r",
-        "title": "Base simulation wire: Diligence → success-rate modifier",
+        "id": "Sylveste-8ew7",
+        "title": "Generators run on --help instead of printing usage",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Base simulation wire: Diligence → success-rate modifier"
+        "notes": "Generators run on --help instead of printing usage"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-vrt6",
-        "title": "Posture formula separation: Thoroughness/Diligence and Improvisation/Creativity",
+        "id": "Sylveste-oz7o",
+        "title": "interchart artefact still machine-dependent after the case fix",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Posture formula separation: Thoroughness/Diligence and Improvisation/Creativity"
+        "notes": "interchart artefact still machine-dependent after the case fix"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-fjo9",
-        "title": "Scenario: Author 2-3 additional scenario seed configs",
+        "id": "Sylveste-m3wd",
+        "title": "interlore is on master, not main, against the estate convention",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Scenario: Author 2-3 additional scenario seed configs"
+        "notes": "interlore is on master, not main, against the estate convention"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-t84f.2",
-        "title": "Break up oversized mixed-responsibility modules uncovered by perf review",
+        "id": "Sylveste-0fd",
+        "title": "interchart: regenerate-and-deploy.sh doesn't deploy — only pushes to GitHub",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Break up oversized mixed-responsibility modules uncovered by perf review"
+        "notes": "interchart: regenerate-and-deploy.sh doesn't deploy — only pushes to GitHub"
+      },
+      {
+        "module": "clavain",
+        "id": "Sylveste-u59",
+        "title": "Config adoption pass: fallbackModel chain, Tool(param:value) permission rules, sandbox.credentials/deniedDomains",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Config adoption pass: fallbackModel chain, Tool(param:value) permission rules, sandbox.credentials/deniedDomains"
+      },
+      {
+        "module": "interspect",
+        "id": "Sylveste-uiw",
+        "title": "Ingest OTEL workflow.run_id + agent_id/parent_agent_id span attribution as routing evidence",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Ingest OTEL workflow.run_id + agent_id/parent_agent_id span attribution as routing evidence"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-7hli",
-        "title": "TUI: Finance and political capital detail view",
+        "id": "Sylveste-omz",
+        "title": "Research spike: temporal fact-invalidation (t_valid/t_invalid) for intermem",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "TUI: Finance and political capital detail view"
+        "notes": "Research spike: temporal fact-invalidation (t_valid/t_invalid) for intermem"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-9l5j",
-        "title": "TUI: F-key panel switching (Bloomberg function keys)",
+        "id": "Sylveste-05t",
+        "title": "Research spike: self-speculative decoding via native MTP heads on downloaded MoE checkpoints",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "TUI: F-key panel switching (Bloomberg function keys)"
+        "notes": "Research spike: self-speculative decoding via native MTP heads on downloaded MoE checkpoints"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-alej",
-        "title": "TUI: Command bar (Bloomberg-style)",
+        "id": "Sylveste-0ww",
+        "title": "Research spike: null-test graph/lens retrieval vs naive baseline on real Auraken/lattice queries",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "TUI: Command bar (Bloomberg-style)"
+        "notes": "Research spike: null-test graph/lens retrieval vs naive baseline on real Auraken/lattice queries"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-rqfo",
-        "title": "TUI: Interactive recruit and deploy",
+        "id": "Sylveste-i3h",
+        "title": "Research spike: expert-activation traces → Belady-approximating cache policy for flash-moe",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "TUI: Interactive recruit and deploy"
+        "notes": "Research spike: expert-activation traces → Belady-approximating cache policy for flash-moe"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-mi3",
-        "title": "TUI: Pressure matrix heatmap",
+        "id": "Sylveste-tpc",
+        "title": "Research spike: lens authoring-drift pairs (sylveste-05rf) as semantic versioning",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "TUI: Pressure matrix heatmap"
+        "notes": "Research spike: lens authoring-drift pairs (sylveste-05rf) as semantic versioning"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-6mc",
-        "title": "TUI: Active deployments panel",
+        "id": "Sylveste-4b8",
+        "title": "Research spike: LLM-judge reliability harness for interflux + cross-model consensus test",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "TUI: Active deployments panel"
+        "notes": "Research spike: LLM-judge reliability harness for interflux + cross-model consensus test"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-i3s",
-        "title": "TUI: Active issues panel",
+        "id": "Sylveste-ry3",
+        "title": "Research spike: orchestrator-visibility safety audit (hidden dispatch vs dissent suppression)",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "TUI: Active issues panel"
+        "notes": "Research spike: orchestrator-visibility safety audit (hidden dispatch vs dissent suppression)"
       },
       {
         "module": "sylveste",
-        "id": "Revel-p6m",
-        "title": "Full art data files — 36 base types, 40+ prefixes, 50+ suffixes",
+        "id": "Sylveste-va4",
+        "title": "Research spike: M5 Neural Accelerator prefill/decode asymmetry measurement",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Full art data files — 36 base types, 40+ prefixes, 50+ suffixes"
+        "notes": "Research spike: M5 Neural Accelerator prefill/decode asymmetry measurement"
+      },
+      {
+        "module": "upstream-sync",
+        "id": "Sylveste-ie6.6",
+        "title": "product-pulse: read-side user-outcome telemetry loop",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "product-pulse: read-side user-outcome telemetry loop"
+      },
+      {
+        "module": "upstream-sync",
+        "id": "Sylveste-ie6.5",
+        "title": "ce-ideate-style pre-brainstorm idea generation+critique stage",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "ce-ideate-style pre-brainstorm idea generation+critique stage"
+      },
+      {
+        "module": "upstream-sync",
+        "id": "Sylveste-ie6.4",
+        "title": "compound-refresh: staleness audit for docs/solutions KB",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "compound-refresh: staleness audit for docs/solutions KB"
+      },
+      {
+        "module": "auraken",
+        "id": "Sylveste-8p3",
+        "title": "AURAKEN_BOOTSTRAP=off builder bypass for onboarding arc",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "AURAKEN_BOOTSTRAP=off builder bypass for onboarding arc"
       },
       {
         "module": "sylveste",
-        "id": "Revel-gn9",
-        "title": "Cuisine quality system",
+        "id": "Sylveste-4b5.23",
+        "title": "CoAgent live-external-state concurrency watch-item (gated, self-limiting, kill-dated)",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Cuisine quality system"
+        "notes": "CoAgent live-external-state concurrency watch-item (gated, self-limiting, kill-dated)"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-6m3",
-        "title": "Research: worldmonitor (GitHub) — real-time global monitoring reference",
+        "id": "Sylveste-4b5.22",
+        "title": "Local lint-triage classifier feasibility (s10 child, measure-only, likely-moot)",
         "phase": "later",
         "priority": "P3",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Research: worldmonitor (GitHub) — real-time global monitoring reference"
+        "notes": "Local lint-triage classifier feasibility (s10 child, measure-only, likely-moot)"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-7zi",
-        "title": "Research: Situational Unawareness (The Baffler) — intelligence dashboard critique",
+        "id": "Sylveste-4b5.21",
+        "title": "interrank benchmark source-provenance ranking input (child of s3z6, gated on s10)",
         "phase": "later",
         "priority": "P3",
-        "status": "open",
+        "status": "blocked",
         "source": "beads",
         "source_file": "beads",
-        "blocked_by": [],
-        "notes": "Research: Situational Unawareness (The Baffler) — intelligence dashboard critique"
-      },
-      {
-        "module": "Post-v1",
-        "id": "shadow-work-872",
-        "title": "Web distribution — WASM binary size optimization (Phase 3)",
-        "phase": "later",
-        "priority": "P3",
-        "status": "open",
-        "source": "beads",
-        "source_file": "beads",
-        "blocked_by": [],
-        "notes": "Web distribution — WASM binary size optimization (Phase 3)"
-      },
-      {
-        "module": "Post-v1",
-        "id": "shadow-work-hm3",
-        "title": "Cross-platform packaging",
-        "phase": "later",
-        "priority": "P3",
-        "status": "open",
-        "source": "beads",
-        "source_file": "beads",
-        "blocked_by": [],
-        "notes": "Cross-platform packaging"
-      },
-      {
-        "module": "Post-v1",
-        "id": "shadow-work-3ni",
-        "title": "Historical replay — golden seed",
-        "phase": "later",
-        "priority": "P3",
-        "status": "open",
-        "source": "beads",
-        "source_file": "beads",
-        "blocked_by": [],
-        "notes": "Historical replay — golden seed"
-      },
-      {
-        "module": "Post-v1",
-        "id": "shadow-work-bi5",
-        "title": "Secondary focal countries",
-        "phase": "later",
-        "priority": "P3",
-        "status": "open",
-        "source": "beads",
-        "source_file": "beads",
-        "blocked_by": [],
-        "notes": "Secondary focal countries"
+        "blocked_by": [
+          "sylveste-s3z6"
+        ],
+        "notes": "interrank benchmark source-provenance ranking input (child of s3z6, gated on s10)"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-byob",
-        "title": "TUI: SW_API_KEY auth support",
+        "id": "Sylveste-4b5.20",
+        "title": "VerifyLoop feasibility — self-generated-oracle iteration vs TDD baseline (research spike)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-6h7x"
+        ],
+        "notes": "VerifyLoop feasibility — self-generated-oracle iteration vs TDD baseline (research spike)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-4b5.19",
+        "title": "Contamination-resistant benchmark re-pin (deferred, gated on harness consuming a routing decision)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Contamination-resistant benchmark re-pin (deferred, gated on harness consuming a routing decision)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-4b5.18",
+        "title": "Cache-aware effective-cost term in B2 routing (child of xka6, gated on enforce)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-xka6"
+        ],
+        "notes": "Cache-aware effective-cost term in B2 routing (child of xka6, gated on enforce)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-4b5.17",
+        "title": "Rimsky (3kol) topology doc-hygiene: record flat-fan-out structural rule",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Rimsky (3kol) topology doc-hygiene: record flat-fan-out structural rule"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-22oi.6",
+        "title": "Reconcile stale non-dist SKILL.md duplicate in Auraken Hermes tree",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Reconcile stale non-dist SKILL.md duplicate in Auraken Hermes tree"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-lgci",
+        "title": "A:L4 — evaluate skill-selection calibration as a 4th autonomy loop (post-v0.7)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "A:L4 — evaluate skill-selection calibration as a 4th autonomy loop (post-v0.7)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-7aj8.6",
+        "title": "interspect skillcal: tune-overlays — skill_tune action + overlay format",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-ysny"
+        ],
+        "notes": "interspect skillcal: tune-overlays — skill_tune action + overlay format"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-7aj8.7",
+        "title": "interspect skillcal: canary + autonomy — regression trigger + safe-list",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-ysny"
+        ],
+        "notes": "interspect skillcal: canary + autonomy — regression trigger + safe-list"
+      },
+      {
+        "module": "clavain",
+        "id": "sylveste-kogm",
+        "title": "/context-restore + structured WIP-commit metadata (parked)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "/context-restore + structured WIP-commit metadata (parked)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-55hj",
+        "title": "Agent fitness decay (finding->commit integration rate)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Agent fitness decay (finding->commit integration rate)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-z0pc",
+        "title": "Skill-description boilerplate standardization via interskill:audit",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Skill-description boilerplate standardization via interskill:audit"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-tsvw",
+        "title": "intercore coordination quota/fairness (pre-scale insurance)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "intercore coordination quota/fairness (pre-scale insurance)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-dxt7",
+        "title": "intercore gate-rule registry (OS-layer extensibility)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "intercore gate-rule registry (OS-layer extensibility)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-31v",
+        "title": "Run install-macos.sh on Mac to restore claude-plugin-cleanup.sh + LaunchAgent",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "Sylveste-942"
+        ],
+        "notes": "Run install-macos.sh on Mac to restore claude-plugin-cleanup.sh + LaunchAgent"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-942",
+        "title": "Fix /Users/arouth hardcoded path in com.arouth.claude-plugin-cleanup.plist",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Fix /Users/arouth hardcoded path in com.arouth.claude-plugin-cleanup.plist"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-jciw",
+        "title": "clavain-cli sprint-init gate diverges from bd doctor (false-positive '1 error(s)')",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "clavain-cli sprint-init gate diverges from bd doctor (false-positive '1 error(s)')"
+      },
+      {
+        "module": "scoping",
+        "id": "Sylveste-s10",
+        "title": "Small-local-model (sub-10B) workload candidates after microrouter cluster close",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Small-local-model (sub-10B) workload candidates after microrouter cluster close"
+      },
+      {
+        "module": "routing",
+        "id": "Sylveste-23w",
+        "title": "Propagate verify_frontmatter.py + routing-drift workflow to sibling subrepos",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Propagate verify_frontmatter.py + routing-drift workflow to sibling subrepos"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-c231",
+        "title": "Add quarantined-worktree disposal runbook to Sylveste docs (generic version of elf-revel solutions doc)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Add quarantined-worktree disposal runbook to Sylveste docs (generic version of elf-revel solutions doc)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-9xyh",
+        "title": "beads: bd dolt status errors with 'not supported in embedded mode' but bd dolt help lists it unconditionally under Server lifecycle",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "beads: bd dolt status errors with 'not supported in embedded mode' but bd dolt help lists it unconditionally under Server lifecycle"
+      },
+      {
+        "module": "interstat",
+        "id": "Sylveste-xvt",
+        "title": "Investigate hash-ID fallback: 70% of subagent rows have unparseable agent_name",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Investigate hash-ID fallback: 70% of subagent rows have unparseable agent_name"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-sox",
+        "title": "xp7-c: investigate why Claude Code plugin auto-loader silently drops interlock hooks",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "xp7-c: investigate why Claude Code plugin auto-loader silently drops interlock hooks"
+      },
+      {
+        "module": "routing",
+        "id": "Sylveste-7zi",
+        "title": "Investigate fd-architecture/fd-systems opus-vs-sonnet disagreement",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Investigate fd-architecture/fd-systems opus-vs-sonnet disagreement"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-a4oj.9.3.1",
+        "title": "Semantic-embedding dup detection (extends 9.3 lexical baseline)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Semantic-embedding dup detection (extends 9.3 lexical baseline)"
+      },
+      {
+        "module": "interspect",
+        "id": "sylveste-sfhq.4",
+        "title": "Tool-remediation canary + revert plumbing (sfhq.3 follow-up)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Tool-remediation canary + revert plumbing (sfhq.3 follow-up)"
+      },
+      {
+        "module": "interfer",
+        "id": "Sylveste-uk3",
+        "title": "OpenRouter stream usage block omits reasoning_tokens — gen_tps/cost telemetry undercounts on bvh",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "OpenRouter stream usage block omits reasoning_tokens — gen_tps/cost telemetry undercounts on bvh"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-y6m7",
+        "title": "Audit + clean parent-epic depends_on edges in b1ha (and other epics)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Audit + clean parent-epic depends_on edges in b1ha (and other epics)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-z1sq",
+        "title": "interline statusline: scope next_bead to session lane (tmux name)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "interline statusline: scope next_bead to session lane (tmux name)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-3xl3.8",
+        "title": "flux-explore --teams Approach 3: full team-driven exploration",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-3xl3.7"
+        ],
+        "notes": "flux-explore --teams Approach 3: full team-driven exploration"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-a4oj.14",
+        "title": "M-01 follow-up: per-project user-scope MCP server suppression (mcpProfile-equivalent)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "M-01 follow-up: per-project user-scope MCP server suppression (mcpProfile-equivalent)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-3xl3.6",
+        "title": "Plan-approval teammate mode → quality-gates / authz framework integration",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Plan-approval teammate mode → quality-gates / authz framework integration"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-3xl3.5",
+        "title": "Audit fd-* and researcher agent definitions for teammate-role reuse",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Audit fd-* and researcher agent definitions for teammate-role reuse"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.32.6.10",
+        "title": "BP-C1.B.drift: migrate fluxbench-drift.sh registry writes (needs flock restructure)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "BP-C1.B.drift: migrate fluxbench-drift.sh registry writes (needs flock restructure)"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.32.6.11",
+        "title": "BP-C1.B.discover: migrate discover-merge.sh registry writes (needs add-model primitive)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "BP-C1.B.discover: migrate discover-merge.sh registry writes (needs add-model primitive)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-r5t",
+        "title": "Clavain: investigate skill-precedence — ~/.claude/skills/ override didn't beat cached plugin SKILL.md",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Clavain: investigate skill-precedence — ~/.claude/skills/ override didn't beat cached plugin SKILL.md"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-46v",
+        "title": "Clavain: clean stale publish_state rows + audit cross-marketplace drift",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Clavain: clean stale publish_state rows + audit cross-marketplace drift"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-a4oj.12",
+        "title": "Memory depth-tiered archiving: project_status frontmatter + close-off depth automation",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Memory depth-tiered archiving: project_status frontmatter + close-off depth automation"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-a4oj.10",
+        "title": "Phase 3 — Infrastructure-class improvements (M+ difficulty bundle)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Phase 3 — Infrastructure-class improvements (M+ difficulty bundle)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-oyrf.3",
+        "title": "90s self-building asciicast per fd-demo-artifact-authenticity shot list",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "90s self-building asciicast per fd-demo-artifact-authenticity shot list"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-rm8w",
+        "title": "lattice: function diagnostic property mismatch (families.py vs diagnostics.py)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "lattice: function diagnostic property mismatch (families.py vs diagnostics.py)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-fj1w",
+        "title": "Clavain peer-coexistence B′ — peer-aware using-clavain + peers.yaml registry (gated on telemetry)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Clavain peer-coexistence B′ — peer-aware using-clavain + peers.yaml registry (gated on telemetry)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-wdf2.3",
+        "title": "L3+L4: /schedule routines for floor refresh and monthly audit",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "L3+L4: /schedule routines for floor refresh and monthly audit"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-hfmh",
+        "title": "Retire interscout plugin (deprecated 2026-04-27)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Retire interscout plugin (deprecated 2026-04-27)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-liiu",
+        "title": "Per-hook preamble byte telemetry for automatic regression detection",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Per-hook preamble byte telemetry for automatic regression detection"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-hvmc",
+        "title": "intermute live transport v1.5: active-probe readiness check (replaces 2s staleness)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "intermute live transport v1.5: active-probe readiness check (replaces 2s staleness)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-nxfq",
+        "title": "sprint: automated import-graph assertion from plan's structural requirements",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "sprint: automated import-graph assertion from plan's structural requirements"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-1h0b",
+        "title": "Build Komoroske profile via proven pipeline (return from deferral)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-am7w",
+          "sylveste-f314"
+        ],
+        "notes": "Build Komoroske profile via proven pipeline (return from deferral)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-52ys",
+        "title": "Rao profile (self-referential essay-chain test)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-2xzz",
+          "sylveste-am7w",
+          "sylveste-1nvc"
+        ],
+        "notes": "Rao profile (self-referential essay-chain test)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-8g69",
+        "title": "Thompson profile or substitute (analytical-framework consistency test)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-am7w",
+          "sylveste-1nvc",
+          "sylveste-2xzz"
+        ],
+        "notes": "Thompson profile or substitute (analytical-framework consistency test)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-9prl",
+        "title": "Wei profile (rare-frame detection test)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-1nvc",
+          "sylveste-am7w",
+          "sylveste-2xzz"
+        ],
+        "notes": "Wei profile (rare-frame detection test)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-ovux",
+        "title": "Upstream Hermes skill frontmatter aliases (support /ak for /auraken natively)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Upstream Hermes skill frontmatter aliases (support /ak for /auraken natively)"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-aso",
+        "title": "Umbrella gitignore: docs/research/*/ rule is leaky for nested content",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Umbrella gitignore: docs/research/*/ rule is leaky for nested content"
+      },
+      {
+        "module": "sylveste",
+        "id": "Sylveste-bgj",
+        "title": "Unify docs/prd/ and docs/prds/ directory structure",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Unify docs/prd/ and docs/prds/ directory structure"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-gaid",
+        "title": "Auraken: SKILL.md cross-model voice portability — potential research finding",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Auraken: SKILL.md cross-model voice portability — potential research finding"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-jp1l",
+        "title": "interjawn MCP server fails to start — Prisma ESM export error",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "interjawn MCP server fails to start — Prisma ESM export error"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-oyrf",
+        "title": "Longitudinal cost-calibration + Mythos launch artifacts",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Longitudinal cost-calibration + Mythos launch artifacts"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-3rod",
+        "title": "Sylveste Mythos launch readiness — 3-month focus + launch-on-drop trigger",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-myyw",
+          "sylveste-nzhl",
+          "sylveste-oyrf"
+        ],
+        "notes": "Sylveste Mythos launch readiness — 3-month focus + launch-on-drop trigger"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-4epi",
+        "title": "Interlab observability audit — masaq METRIC wrappers (dxzr successor)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Interlab observability audit — masaq METRIC wrappers (dxzr successor)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-p2yj",
+        "title": "Go benchmark-driven optimization for Skaffen hot paths (0pvp successor)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Go benchmark-driven optimization for Skaffen hot paths (0pvp successor)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-w4sj",
+        "title": "v1.0 roadmap artifact publishing (enxv successor)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "v1.0 roadmap artifact publishing (enxv successor)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-fba8",
+        "title": "Hardware-aware model recommendations in interrank (1ifn successor)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Hardware-aware model recommendations in interrank (1ifn successor)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-lbkd",
+        "title": "Sprint v2 artifact bus + progress trackers (lta9 successor)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Sprint v2 artifact bus + progress trackers (lta9 successor)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-lpnd",
+        "title": "ATTP attestation protocol for interweave (e1mi successor)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "ATTP attestation protocol for interweave (e1mi successor)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-jsyc",
+        "title": "F6: Big-bang cutover — remove legacy mcpServers entries",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-lbvq",
+          "sylveste-39p5",
+          "sylveste-7505"
+        ],
+        "notes": "F6: Big-bang cutover — remove legacy mcpServers entries"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-amcz",
+        "title": "F2: interserve-py adapter framework",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-7505",
+          "sylveste-h4mw"
+        ],
+        "notes": "F2: interserve-py adapter framework"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-h4mw",
+        "title": "F1: interserve plugin scaffold",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-7505"
+        ],
+        "notes": "F1: interserve plugin scaffold"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-fyo3.11",
+        "title": "P3: Oracle cross-AI review integration — enable non-Claude peer review via Oracle binary",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "P3: Oracle cross-AI review integration — enable non-Claude peer review via Oracle binary"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-fyo3.10",
+        "title": "P3: Weekly discovery agent automation — run fluxbench-discover.md on cron schedule",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-fyo3.2"
+        ],
+        "notes": "P3: Weekly discovery agent automation — run fluxbench-discover.md on cron schedule"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-fyo3.7",
+        "title": "P2: Interspect overlay activation — promote from progressive enhancement to default",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "P2: Interspect overlay activation — promote from progressive enhancement to default"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-nr6x.12",
+        "title": "Infra: install signal-cli + register hassease Signal account",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Infra: install signal-cli + register hassease Signal account"
+      },
+      {
+        "module": "interfer",
+        "id": "sylveste-7hxm",
+        "title": "Route-heuristic-coverage interlab campaign",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Route-heuristic-coverage interlab campaign"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-u6fj",
+        "title": "F7: interkasten migration + archival",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-bcok"
+        ],
+        "notes": "F7: interkasten migration + archival"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-8qk",
+        "title": "F8: Philosophy amendment + documentation",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "F8: Philosophy amendment + documentation"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.29",
+        "title": "P3: Triage subagent — offload Steps 1.0-1.2 from host context",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "P3: Triage subagent — offload Steps 1.0-1.2 from host context"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.28",
+        "title": "P3: Per-finding sycophancy detection — architecture ready in reaction.yaml, deferred until fleet grows",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "P3: Per-finding sycophancy detection — architecture ready in reaction.yaml, deferred until fleet grows"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.27",
+        "title": "P3: Domain-specific research agents — flux-gen equivalent for research side",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "P3: Domain-specific research agents — flux-gen equivalent for research side"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.26",
+        "title": "P3: Query decomposition for complex research — confirmed v2, focus on exploratory+onboarding types",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "P3: Query decomposition for complex research — confirmed v2, focus on exploratory+onboarding types"
+      },
+      {
+        "module": "interflux",
+        "id": "sylveste-9lp.25",
+        "title": "P3: Learned orchestration from run history — requires labeled negative data",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "P3: Learned orchestration from run history — requires labeled negative data"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7.21",
+        "title": "Explore occlusion culling — skip background content behind modal dialogs",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Explore occlusion culling — skip background content behind modal dialogs"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7.22",
+        "title": "Document vision token cache disadvantage for multi-turn agent sessions",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Document vision token cache disadvantage for multi-turn agent sessions"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7.19",
+        "title": "Add agent backchanneling — LLM negotiates detail level",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Add agent backchanneling — LLM negotiates detail level"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7.20",
+        "title": "Add color semantics lookup table for common terminal applications",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Add color semantics lookup table for common terminal applications"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7.18",
+        "title": "Add task-adapted rendering profiles (interactive/content/structure)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Add task-adapted rendering profiles (interactive/content/structure)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7.16",
+        "title": "Add information hierarchy (L0/L1/L2/L3) to all output modes",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Add information hierarchy (L0/L1/L2/L3) to all output modes"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7.17",
+        "title": "Add multi-pane marshalling — named pane composition for tmux/splits",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Add multi-pane marshalling — named pane composition for tmux/splits"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7.15",
+        "title": "Add generative encoding for structured UI — template+data instead of full render",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Add generative encoding for structured UI — template+data instead of full render"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7.11",
+        "title": "Separate UI chrome (borders, status lines) from content in output",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Separate UI chrome (borders, status lines) from content in output"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7.12",
+        "title": "Add channel-selective encoding — callers choose which attributes to include",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Add channel-selective encoding — callers choose which attributes to include"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7.13",
+        "title": "Add session-local dictionary for repeated content patterns",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Add session-local dictionary for repeated content patterns"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7.9",
+        "title": "Add semantic role annotations (ARIA-like) for terminal elements",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Add semantic role annotations (ARIA-like) for terminal elements"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7.8",
+        "title": "Add diff/delta mode with auto-refresh every 5 turns",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Add diff/delta mode with auto-refresh every 5 turns"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7.7",
+        "title": "SVG CSS class dictionary — deduplicate repeated class/color attributes",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "SVG CSS class dictionary — deduplicate repeated class/color attributes"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-sn7.6",
+        "title": "Add motif/summary LOD level (L0) for polling tasks",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Add motif/summary LOD level (L0) for polling tasks"
+      },
+      {
+        "module": "auraken",
+        "id": "sylveste-2l1.7",
+        "title": "Arctic Shift extraction for niche subreddits",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Arctic Shift extraction for niche subreddits"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-e20",
+        "title": "/intersite:publish with atomic swap deploy",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "/intersite:publish with atomic swap deploy"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-6zy",
+        "title": "xterm.js slide-out panel component for project pages",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "xterm.js slide-out panel component for project pages"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-gw6",
+        "title": "WebSocket PTY relay service at apps/intersite-relay/",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "WebSocket PTY relay service at apps/intersite-relay/"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-fdn",
+        "title": "301 redirect: blog.generalsystemsventures.com to /blog/",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "301 redirect: blog.generalsystemsventures.com to /blog/"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-5va",
+        "title": "Auto-generate graph edges from content themes + lineage fields",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Auto-generate graph edges from content themes + lineage fields"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-m5g",
+        "title": "intersite-relay: xterm.js dev panel + WebSocket PTY relay",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "intersite-relay: xterm.js dev panel + WebSocket PTY relay"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-rsj.3.6",
+        "title": "GameDevBench integration: add game-building benchmark alongside SWE-bench for complex multi-file evaluation",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "GameDevBench integration: add game-building benchmark alongside SWE-bench for complex multi-file evaluation"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-rsj.3.4",
+        "title": "Permaconsequence visibility: make cross-session evidence compounding visible in Garden Salon UX",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Permaconsequence visibility: make cross-session evidence compounding visible in Garden Salon UX"
+      },
+      {
+        "module": "interproof",
+        "id": "sylveste-ayl",
+        "title": "Manual-driven feature validation plugin",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Manual-driven feature validation plugin"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-naj",
+        "title": "BHQ speed optimization via autoresearch",
+        "phase": "later",
+        "priority": "P3",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-d5e"
+        ],
+        "notes": "BHQ speed optimization via autoresearch"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-308",
+        "title": "Autoresearch: SSD page cache pre-fetching for 397B streaming",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-4l2",
+          "sylveste-1qa"
+        ],
+        "notes": "Autoresearch: SSD page cache pre-fetching for 397B streaming"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-3uy",
+        "title": "Autoresearch: Metal compute shader optimization",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-i8u",
+          "sylveste-1qa"
+        ],
+        "notes": "Autoresearch: Metal compute shader optimization"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-4wl",
+        "title": "Autoresearch: adaptive batching parameters for concurrent agents",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-5ne",
+          "sylveste-1qa"
+        ],
+        "notes": "Autoresearch: adaptive batching parameters for concurrent agents"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-9tc",
+        "title": "Autoresearch: LayerSkip exit threshold tuning",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-qbv",
+          "sylveste-1qa"
+        ],
+        "notes": "Autoresearch: LayerSkip exit threshold tuning"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-ji6",
+        "title": "Experiment: Multi-head Latent Attention (MLA) for KV compression",
+        "phase": "later",
+        "priority": "P3",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Experiment: Multi-head Latent Attention (MLA) for KV compression"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-f0k",
+        "title": "Experiment: reservoir computing readout for task routing",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Experiment: reservoir computing readout for task routing"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-xc8",
+        "title": "Experiment: memory wiring and page cache optimization for SSD streaming",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-4l2"
+        ],
+        "notes": "Experiment: memory wiring and page cache optimization for SSD streaming"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-i8u",
+        "title": "Experiment: custom Metal compute shaders for mlx-lm",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Experiment: custom Metal compute shaders for mlx-lm"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-1zh",
+        "title": "Experiment: StreamingLLM attention sinks for infinite context",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Experiment: StreamingLLM attention sinks for infinite context"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-37g",
+        "title": "Experiment: Mixture of Depths (MoD) dynamic layer routing",
+        "phase": "later",
+        "priority": "P3",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Experiment: Mixture of Depths (MoD) dynamic layer routing"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-8v3",
+        "title": "Benchmark Kimi K2.5 3-bit (1T, 32B active)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-4l2"
+        ],
+        "notes": "Benchmark Kimi K2.5 3-bit (1T, 32B active)"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-bpg",
+        "title": "Benchmark GLM-5 4-bit (744B, 40B active)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-4l2"
+        ],
+        "notes": "Benchmark GLM-5 4-bit (744B, 40B active)"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-uln",
+        "title": "Benchmark DeepSeek V3.2 4-bit (672B, ~37B active)",
+        "phase": "later",
+        "priority": "P3",
+        "status": "blocked",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [
+          "sylveste-4l2"
+        ],
+        "notes": "Benchmark DeepSeek V3.2 4-bit (672B, ~37B active)"
+      },
+      {
+        "module": "observability",
+        "id": "Sylveste-9ve",
+        "title": "Explore subagent dispatches stopped 2026-04-21 — verify whether workflow shift or instrumentation gap",
         "phase": "later",
         "priority": "P4",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "TUI: SW_API_KEY auth support"
+        "notes": "Explore subagent dispatches stopped 2026-04-21 — verify whether workflow shift or instrumentation gap"
       },
       {
-        "module": "sylveste",
-        "id": "shadow-work-nen",
-        "title": "Modding and scenario editor",
+        "module": "routing",
+        "id": "Sylveste-10p",
+        "title": "Add pre-commit hook layer for frontmatter drift (light gate)",
         "phase": "later",
         "priority": "P4",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Modding and scenario editor"
+        "notes": "Add pre-commit hook layer for frontmatter drift (light gate)"
       },
       {
-        "module": "sylveste",
-        "id": "shadow-work-wbd",
-        "title": "Multiplayer — shared worlds",
+        "module": "routing",
+        "id": "Sylveste-vft",
+        "title": "Drift baseline ratcheting — committed .routing-drift-baseline file",
         "phase": "later",
         "priority": "P4",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Multiplayer — shared worlds"
+        "notes": "Drift baseline ratcheting — committed .routing-drift-baseline file"
       },
       {
         "module": "sylveste",
-        "id": "shadow-work-j29",
-        "title": "Individual character simulation (Layer 1)",
+        "id": "sylveste-yofd",
+        "title": "Clavain peer-coexistence C′ — full rig manager (profiles, lockfile, per-skill priorities, rig CLI)",
         "phase": "later",
         "priority": "P4",
         "status": "open",
         "source": "beads",
         "source_file": "beads",
         "blocked_by": [],
-        "notes": "Individual character simulation (Layer 1)"
+        "notes": "Clavain peer-coexistence C′ — full rig manager (profiles, lockfile, per-skill priorities, rig CLI)"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-wdf2.4",
+        "title": "L5 (deferred): Substrate-independent external replay",
+        "phase": "later",
+        "priority": "P4",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "L5 (deferred): Substrate-independent external replay"
+      },
+      {
+        "module": "sylveste",
+        "id": "sylveste-zfsj",
+        "title": "intermute live transport v2: cross-host (SSH + tmux orchestration)",
+        "phase": "later",
+        "priority": "P4",
+        "status": "open",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "intermute live transport v2: cross-host (SSH + tmux orchestration)"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-c57",
+        "title": "Experiment: ant colony optimization for expert routing paths",
+        "phase": "later",
+        "priority": "P4",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Experiment: ant colony optimization for expert routing paths"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-eka",
+        "title": "Experiment: thermodynamic-inspired annealing for expert selection",
+        "phase": "later",
+        "priority": "P4",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Experiment: thermodynamic-inspired annealing for expert selection"
+      },
+      {
+        "module": "interfere",
+        "id": "sylveste-0zc",
+        "title": "Experiment: ANE (Apple Neural Engine) offload for attention",
+        "phase": "later",
+        "priority": "P4",
+        "status": "deferred",
+        "source": "beads",
+        "source_file": "beads",
+        "blocked_by": [],
+        "notes": "Experiment: ANE (Apple Neural Engine) offload for attention"
       }
     ]
   },
@@ -2298,9 +8799,57 @@
   "cross_module_dependencies": [],
   "modules_without_roadmaps": [
     {
-      "module": ".clavain",
-      "location": "interverse/.clavain",
+      "module": "auraken",
+      "location": "apps/auraken",
+      "version": "0.1.0",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "interblog",
+      "location": "apps/interblog",
+      "version": "0.1.4",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "intersite",
+      "location": "apps/intersite",
       "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "latro",
+      "location": "apps/latro",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "Meadowsyn",
+      "location": "apps/Meadowsyn",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "agent-rig",
+      "location": "core/agent-rig",
+      "version": "0.1.0",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "interband",
+      "location": "core/interband",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "interbench",
+      "location": "core/interbench",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "interweave",
+      "location": "core/interweave",
+      "version": "0.2.0",
       "notes": "No docs/roadmap.md"
     },
     {
@@ -2310,9 +8859,27 @@
       "notes": "No docs/roadmap.md"
     },
     {
+      "module": ".audit-2026-06-23",
+      "location": "interverse/.audit-2026-06-23",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "cujgel",
+      "location": "interverse/cujgel",
+      "version": "0.2.1",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "interboxd",
+      "location": "interverse/interboxd",
+      "version": "0.1.0",
+      "notes": "No docs/roadmap.md"
+    },
+    {
       "module": "interbrowse",
       "location": "interverse/interbrowse",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "notes": "No docs/roadmap.md"
     },
     {
@@ -2324,13 +8891,19 @@
     {
       "module": "intercept",
       "location": "interverse/intercept",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "notes": "No docs/roadmap.md"
     },
     {
       "module": "interchart",
       "location": "interverse/interchart",
-      "version": "0.1.8",
+      "version": "0.1.9",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "intercut",
+      "location": "interverse/intercut",
+      "version": "0.1.1",
       "notes": "No docs/roadmap.md"
     },
     {
@@ -2352,21 +8925,27 @@
       "notes": "No docs/roadmap.md"
     },
     {
+      "module": "intergraph",
+      "location": "interverse/intergraph",
+      "version": "0.1.0",
+      "notes": "No docs/roadmap.md"
+    },
+    {
       "module": "interhelm",
       "location": "interverse/interhelm",
-      "version": "0.2.2",
+      "version": "0.2.4",
       "notes": "No docs/roadmap.md"
     },
     {
       "module": "interkasten",
       "location": "interverse/interkasten",
-      "version": "0.4.25",
+      "version": "0.4.26",
       "notes": "No docs/roadmap.md"
     },
     {
       "module": "interknow",
       "location": "interverse/interknow",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "notes": "No docs/roadmap.md"
     },
     {
@@ -2376,9 +8955,15 @@
       "notes": "No docs/roadmap.md"
     },
     {
+      "module": "interloop",
+      "location": "interverse/interloop",
+      "version": "0.1.1",
+      "notes": "No docs/roadmap.md"
+    },
+    {
       "module": "interlore",
       "location": "interverse/interlore",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "notes": "No docs/roadmap.md"
     },
     {
@@ -2400,12 +8985,6 @@
       "notes": "No docs/roadmap.md"
     },
     {
-      "module": "interop",
-      "location": "interverse/interop",
-      "version": "—",
-      "notes": "No docs/roadmap.md"
-    },
-    {
       "module": "interpeer",
       "location": "interverse/interpeer",
       "version": "0.1.1",
@@ -2420,13 +8999,13 @@
     {
       "module": "interpulse",
       "location": "interverse/interpulse",
-      "version": "0.1.5",
+      "version": "0.1.10",
       "notes": "No docs/roadmap.md"
     },
     {
       "module": "interrank",
       "location": "interverse/interrank",
-      "version": "0.3.1",
+      "version": "0.3.4",
       "notes": "No docs/roadmap.md"
     },
     {
@@ -2456,7 +9035,7 @@
     {
       "module": "intership",
       "location": "interverse/intership",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "notes": "No docs/roadmap.md"
     },
     {
@@ -2480,13 +9059,19 @@
     {
       "module": "interspect",
       "location": "interverse/interspect",
-      "version": "0.1.22",
+      "version": "0.1.25",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "interstate",
+      "location": "interverse/interstate",
+      "version": "0.5.0",
       "notes": "No docs/roadmap.md"
     },
     {
       "module": "intersynth",
       "location": "interverse/intersynth",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "notes": "No docs/roadmap.md"
     },
     {
@@ -2511,6 +9096,18 @@
       "module": "intertrust",
       "location": "interverse/intertrust",
       "version": "0.1.3",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "intervoice",
+      "location": "interverse/intervoice",
+      "version": "0.1.1",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "intervox",
+      "location": "interverse/intervox",
+      "version": "0.2.0",
       "notes": "No docs/roadmap.md"
     },
     {
@@ -2550,44 +9147,242 @@
       "notes": "No docs/roadmap.md"
     },
     {
-      "module": "Auraken",
-      "location": "apps/Auraken",
-      "version": "0.1.0",
+      "module": "agentic_coding_flywheel_setup",
+      "location": "research/agentic_coding_flywheel_setup",
+      "version": "0.7.0",
       "notes": "No docs/roadmap.md"
     },
     {
-      "module": "Meadowsyn",
-      "location": "apps/Meadowsyn",
+      "module": "agi-hyperspace",
+      "location": "research/agi-hyperspace",
       "version": "—",
       "notes": "No docs/roadmap.md"
     },
     {
-      "module": "interblog",
-      "location": "apps/interblog",
-      "version": "0.1.4",
-      "notes": "No docs/roadmap.md"
-    },
-    {
-      "module": "intersite",
-      "location": "apps/intersite",
-      "version": "0.1.0",
-      "notes": "No docs/roadmap.md"
-    },
-    {
-      "module": "agent-rig",
-      "location": "core/agent-rig",
-      "version": "0.1.0",
-      "notes": "No docs/roadmap.md"
-    },
-    {
-      "module": "interband",
-      "location": "core/interband",
+      "module": "automated_plan_reviser_pro",
+      "location": "research/automated_plan_reviser_pro",
       "version": "—",
       "notes": "No docs/roadmap.md"
     },
     {
-      "module": "interbench",
-      "location": "core/interbench",
+      "module": "beads_for_cass",
+      "location": "research/beads_for_cass",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "beads_rust",
+      "location": "research/beads_rust",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "beads_viewer",
+      "location": "research/beads_viewer",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "beads_viewer_for_agentic_coding_flywheel_setup",
+      "location": "research/beads_viewer_for_agentic_coding_flywheel_setup",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "beads_viewer-pages",
+      "location": "research/beads_viewer-pages",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "cass_memory_system",
+      "location": "research/cass_memory_system",
+      "version": "0.2.3",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "claude_code_agent_farm",
+      "location": "research/claude_code_agent_farm",
+      "version": "1.0.0",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "coding_agent_session_search",
+      "location": "research/coding_agent_session_search",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "cross_agent_session_resumer",
+      "location": "research/cross_agent_session_resumer",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "destructive_command_guard",
+      "location": "research/destructive_command_guard",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "fastmcp_rust",
+      "location": "research/fastmcp_rust",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "flywheel_gateway",
+      "location": "research/flywheel_gateway",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "franken_agent_detection",
+      "location": "research/franken_agent_detection",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "frankensearch",
+      "location": "research/frankensearch",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "frankentui",
+      "location": "research/frankentui",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "gastown",
+      "location": "research/gastown",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "gemini-api-updater-doc",
+      "location": "research/gemini-api-updater-doc",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "get-shit-done",
+      "location": "research/get-shit-done",
+      "version": "1.29.0",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "goosetown",
+      "location": "research/goosetown",
+      "version": "0.1.0",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "gpt-researcher",
+      "location": "research/gpt-researcher",
+      "version": "0.14.7",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "gsv-portfolio-39",
+      "location": "research/gsv-portfolio-39",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "guide_to_openai_response_api_and_agents_sdk",
+      "location": "research/guide_to_openai_response_api_and_agents_sdk",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "hermes_agent",
+      "location": "research/hermes_agent",
+      "version": "1.0.0",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "jido",
+      "location": "research/jido",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "llm_docs",
+      "location": "research/llm_docs",
+      "version": "0.1.0",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "llm_multi_round_coding_tournament",
+      "location": "research/llm_multi_round_coding_tournament",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "mcp_agent_mail",
+      "location": "research/mcp_agent_mail",
+      "version": "0.3.0",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "mcp_agent_mail_rust",
+      "location": "research/mcp_agent_mail_rust",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "meta_skill",
+      "location": "research/meta_skill",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "ntm",
+      "location": "research/ntm",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "pi_agent_rust",
+      "location": "research/pi_agent_rust",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "pi-autoresearch",
+      "location": "research/pi-autoresearch",
+      "version": "1.0.0",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "pi-mono",
+      "location": "research/pi-mono",
+      "version": "0.0.3",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "post_compact_reminder",
+      "location": "research/post_compact_reminder",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "slb",
+      "location": "research/slb",
+      "version": "—",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "ultimate_bug_scanner",
+      "location": "research/ultimate_bug_scanner",
+      "version": "0.0.0",
+      "notes": "No docs/roadmap.md"
+    },
+    {
+      "module": "your-source-to-prompt.html",
+      "location": "research/your-source-to-prompt.html",
       "version": "—",
       "notes": "No docs/roadmap.md"
     }


### PR DESCRIPTION
The tracked artifacts were generated 2026-07-13 and carried the exact defects interpath#1 fixed. They are not on any automatic path — the LaunchAgent writes to `~/.cache/clavain/`, so `docs/roadmap.json` only moves when run by hand.

| | before | after |
|---|---|---|
| items | 62 | 499 |
| open_beads | 62 | 481 |
| blocked | 1 | 128 |
| deferred | 0 | 18 |
| populated `blocked_by` | 1 | 127 |

`deferred: 0` and a single dependency edge were never true readings of this tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)