### PR TITLE
the guard against stale checkouts was reading a cached ref and calling it the remote

### DIFF
--- a/scripts/check-kimi-version-parity.py
+++ b/scripts/check-kimi-version-parity.py
@@ -27,14 +27,26 @@ Usage
     scripts/check-kimi-version-parity.py --root .         # same
     scripts/check-kimi-version-parity.py --estate ~/projects/Sylveste
     scripts/check-kimi-version-parity.py --require-plugins 1
+    scripts/check-kimi-version-parity.py --estate ~/projects/Sylveste \
+        --max-fetch-age-days 7
 
-Exit codes: 0 in parity, 1 drift found, 2 nothing inspected.
+Exit codes: 0 in parity, 1 drift found, 2 could not assess — nothing inspected,
+below the --require-plugins floor, or a finding that only a stale checkout
+supports. Exit 2 is never a claim that something is wrong; it is the refusal to
+make one.
+
+In --estate mode the local clones stand in for what is in git, so their freshness
+is checked before any of them is used to accuse a plugin of drift. In --root mode
+the checkout IS the subject and no freshness rule applies. See remote_evidence().
 """
 
 import argparse
 import json
+import subprocess
 import sys
+import time
 from pathlib import Path
+from typing import NamedTuple
 
 CANONICAL = Path(".claude-plugin") / "plugin.json"
 GENERATED = Path("kimi.plugin.json")
@@ -83,32 +95,115 @@ def plugin_roots(root, estate):
         yield root
 
 
-def behind_remote(plugin: Path) -> int:
-    """How many commits this checkout is behind its remote-tracking branch.
+class Evidence(NamedTuple):
+    """Whether this checkout is a sound basis for accusing a plugin of drift.
+
+    `trustworthy` is the only field the verdict consults. The rest are carried so
+    the report can say WHY, because "cannot assess" without a reason is the kind
+    of output people learn to scroll past.
+    """
+
+    trustworthy: bool
+    reason: str  # empty when trustworthy
+    behind: int | None  # per the cached remote-tracking ref; None = unresolved
+    fetch_age_days: float | None  # None = never fetched since clone
+
+
+def _git(plugin: Path, *args):
+    return subprocess.run(["git", "-C", str(plugin), *args],
+                          capture_output=True, text=True)
+
+
+def last_fetch_age_days(plugin: Path):
+    """Days since this repo last contacted its remote, or None if it never has.
+
+    FETCH_HEAD is rewritten by every fetch and pull and by nothing else, which
+    makes its mtime the only local record of when the remote-tracking refs were
+    last checked against the remote. Its absence means this clone has never
+    fetched.
+
+    The one way this under-reports: `git fetch --no-write-fetch-head` skips the
+    file. Nothing in the estate passes that flag, and the failure is in the safe
+    direction — a repo that fetched would be reported as stale, costing a false
+    "cannot assess" rather than a false accusation.
+    """
+    r = _git(plugin, "rev-parse", "--git-common-dir")
+    if r.returncode != 0:
+        return None
+    common = Path(r.stdout.strip())
+    if not common.is_absolute():
+        common = plugin / common
+    head = common / "FETCH_HEAD"
+    if not head.exists():
+        return None
+    return (time.time() - head.stat().st_mtime) / 86400.0
+
+
+def remote_evidence(plugin: Path, max_fetch_age_days: float) -> Evidence:
+    """Can a drift finding from this checkout be believed?
 
     Parity is a property of what is in git, not of what happens to be on one
-    machine's disk. A checkout that has not pulled will show kimi.plugin.json as
-    absent even though it was committed — which is exactly what happened when
-    this check first ran on zklw: 58 of 65 "out of parity", every one of them a
-    stale working copy rather than real drift.
+    machine's disk. A checkout that has not pulled shows kimi.plugin.json as
+    absent, or shows an old one beside a bumped plugin.json, even though the pair
+    was committed in agreement — which is what happened when this check first ran
+    on zklw: 58 of 65 "out of parity", every one of them a stale working copy
+    rather than real drift.
 
-    A check that reports 58 false alarms gets ignored, so a stale repo must say
-    "I cannot assess this" instead of "this is broken". No fetch: a read-only
-    check must not mutate the repo it inspects, so this uses whatever
-    remote-tracking ref is already there. Returns 0 when it cannot tell.
+    THE FUNCTION THIS REPLACES ANSWERED A DIFFERENT QUESTION THAN IT WAS ASKED.
+    It returned an int, and returned 0 both for "this checkout is level with its
+    remote" and for "I could not find out" — no upstream configured, rev-list
+    failed, unparseable output. Those are opposite states and the caller could
+    not tell them apart, so `if behind:` read a failure to look as evidence of
+    nothing to see.
+
+    Worse, the number it did return was computed against the remote-tracking ref
+    already on disk, and nothing here refreshes that ref. On a clone that last
+    fetched five weeks ago, `HEAD..@{upstream}` is a comparison between two local
+    pointers: it reports 0 with complete confidence and the remote is not
+    involved. Measured 2026-08-07: 55 of 70 Clavain plugin checkouts reported
+    "0 behind" from fetch data older than seven days, twelve of which had never
+    fetched at all, while zklw — whose autosync keeps its checkouts current — had
+    65 of 66 within the week. Both machines got the same integer out of this
+    function. Only one of them had measured anything.
+
+    That is why 2026-08-07 looked like a coverage gap between the machines and
+    was not one. interlore was fixed on the remote on 08-03; Clavain had not
+    fetched; the guard that exists to catch precisely that reported 0.
+
+    NO FETCH, DELIBERATELY. A read-only check must not mutate the repos it
+    inspects — an unattended timer that fetches 70 repos changes their state,
+    can race a session mid-rebase, and turns a checker into a sync tool. So the
+    staleness is REPORTED rather than resolved: this returns how old the evidence
+    is and lets the caller refuse to convict on it. Freshening the estate is
+    autosync's job, and on the machine where it runs, this returns trustworthy.
     """
-    import subprocess
+    if _git(plugin, "rev-parse", "--git-dir").returncode != 0:
+        # Not a git checkout at all. There is no remote for it to be behind and
+        # no ref that could be stale, so the files on disk are the whole of the
+        # available truth and judging them is correct.
+        return Evidence(True, "", None, None)
 
-    r = subprocess.run(
-        ["git", "-C", str(plugin), "rev-list", "--count", "HEAD..@{upstream}"],
-        capture_output=True, text=True,
-    )
+    age = last_fetch_age_days(plugin)
+
+    r = _git(plugin, "rev-list", "--count", "HEAD..@{upstream}")
     if r.returncode != 0:
-        return 0
+        return Evidence(False, "no remote-tracking branch to compare against",
+                        None, age)
     try:
-        return int(r.stdout.strip())
+        behind = int(r.stdout.strip())
     except ValueError:
-        return 0
+        return Evidence(False, "could not read a commit count from git",
+                        None, age)
+
+    if behind:
+        return Evidence(False, f"{behind} commit(s) behind its remote", behind, age)
+    if age is None:
+        return Evidence(False, "never fetched since clone, so '0 behind' compares "
+                               "two local refs", behind, age)
+    if age > max_fetch_age_days:
+        return Evidence(False, f"last fetched {age:.0f}d ago, so '0 behind' is "
+                               f"that old too", behind, age)
+    return Evidence(True, "", behind, age)
 
 
 def main(argv=None):
@@ -117,62 +212,116 @@ def main(argv=None):
     ap.add_argument("--estate", help="walk os/Clavain + interverse/* under this root")
     ap.add_argument("--require-plugins", type=int, default=0, metavar="N",
                     help="fail if fewer than N plugins were inspected")
+    ap.add_argument("--max-fetch-age-days", type=float, default=7.0, metavar="D",
+                    help="estate mode: a checkout that has not fetched within D "
+                         "days cannot support a drift finding (default 7)")
     args = ap.parse_args(argv)
 
     root = Path(args.root).resolve()
     estate = Path(args.estate).resolve() if args.estate else None
 
+    # THE FRESHNESS GUARD IS AN ESTATE-MODE RULE ONLY, and the distinction is
+    # load-bearing rather than cautious. The two modes ask different questions of
+    # the same files:
+    #
+    #   --root  is a plugin repo checking ITSELF, in its own CI and pre-commit
+    #           hook. That tree is the subject, not a proxy for one, so its
+    #           agreement with a remote is beside the point. CI also checks out a
+    #           detached HEAD, where `@{upstream}` does not resolve at all — so a
+    #           guard that treats "no upstream" as "cannot judge" would turn the
+    #           enforced check off precisely where it is enforced, and the check
+    #           would go on exiting 0 while catching nothing.
+    #
+    #   --estate walks 70 local clones as STAND-INS for what is in git. There the
+    #           age of the stand-in is the whole question.
+    check_freshness = estate is not None
+    trusted = Evidence(True, "", None, None)
+
     inspected = 0
     drift = []
     unassessable = []
+    unproven = 0  # in parity here, on evidence too old to prove it anywhere else
     for plugin in plugin_roots(root, estate):
         inspected += 1
         canonical = plugin / CANONICAL
         generated = plugin / GENERATED
         want = read_version(canonical)
 
+        # Decide WHAT the finding is first, and only then whether this checkout
+        # is entitled to make it. The version that shipped asked those two
+        # questions in the wrong order: it consulted the remote only on the
+        # missing-file branch, so a present-but-stale kimi.plugin.json beside a
+        # bumped plugin.json — the interlore shape, and by far the most common
+        # one — was accused without the guard ever being called.
         if not generated.is_file():
-            behind = behind_remote(plugin)
-            if behind:
-                unassessable.append((plugin.name, behind))
+            finding = (want, None, "kimi.plugin.json is missing")
+        else:
+            got = read_version(generated)
+            if not usable(want) or not usable(got):
+                finding = (want, got, "no readable version to compare")
+            elif got != want:
+                finding = (want, got, "version bumped without regenerating")
             else:
-                drift.append((plugin.name, want, None,
-                              "kimi.plugin.json is missing"))
+                finding = None
+
+        ev = remote_evidence(plugin, args.max_fetch_age_days) if check_freshness \
+            else trusted
+
+        if finding is None:
+            # A clean pair proves parity HERE. On a checkout that has not fetched
+            # it proves nothing about the repo, because the bump may be sitting
+            # unpulled. That is a limit on coverage rather than a false
+            # accusation, so it does not move the verdict — but it is counted and
+            # said out loud, because a pass whose basis is a month old should not
+            # read identically to one taken this morning.
+            if not ev.trustworthy:
+                unproven += 1
             continue
-        got = read_version(generated)
-        if not usable(want) or not usable(got):
-            # Reported as drift rather than as unassessable on purpose. The
-            # `unassessable` bucket below is for facts about THIS MACHINE — a
-            # checkout too stale to judge from — and a manifest with no readable
-            # version is not that. It is a defect in the plugin repo, it travels
-            # with the repo, and pulling will not fix it.
-            drift.append((plugin.name, want, got,
-                          "no readable version to compare"))
-            continue
-        if got != want:
-            drift.append((plugin.name, want, got,
-                          "version bumped without regenerating"))
+
+        if ev.trustworthy:
+            drift.append((plugin.name, *finding))
+        else:
+            unassessable.append((plugin.name, ev.reason, finding[2]))
 
     for name, want, got, why in drift:
         print(f"DRIFT  {name}: {why} "
               f"(plugin.json={want} kimi.plugin.json={got})", file=sys.stderr)
 
-    for name, behind in unassessable:
-        print(f"STALE  {name}: {behind} commit(s) behind its remote — parity "
-              f"cannot be judged from this checkout", file=sys.stderr)
+    for name, reason, suppressed in unassessable:
+        # Name the accusation that was withheld, not just the fact of withholding
+        # it. "STALE foo: 3 commits behind" told a reader nothing about whether
+        # pulling would reveal a real problem or a non-event.
+        print(f"STALE  {name}: would have reported '{suppressed}', but this "
+              f"checkout cannot support it — {reason}", file=sys.stderr)
 
-    # A checkout too stale to judge is not a pass. Report it as could-not-run
-    # rather than letting an unpulled machine either cry wolf or look healthy.
-    if unassessable and len(unassessable) > len(drift):
-        print(f"\nCANNOT ASSESS: {len(unassessable)} of {inspected} plugin(s) are "
-              f"behind their remotes. Pull them, then re-run — this checkout is "
-              f"not a valid basis for a parity verdict.", file=sys.stderr)
-        return 2
+    # How old the evidence is, stated rather than assumed. This is the half of
+    # the fix that is not a verdict change: on a machine whose clones do not
+    # fetch, most of a green run rests on data nobody refreshed, and the run
+    # should say so instead of reading exactly like a run on a current checkout.
+    # Say what the count is a count OF. The first version of this line read
+    # "N judged from fetch data older than 7d", which was true of most of the 65
+    # it reported on Clavain and false of ten: nine clones that had fetched
+    # recently enough to know they were behind, and one with no upstream at all.
+    # Those cannot support a verdict either, but not for that reason, and a
+    # summary that names one cause for three states is the kind of true-sounding
+    # sentence this check exists to stop shipping.
+    staleness = ""
+    if unproven:
+        staleness = (f"; {unproven} of {inspected} judged on remote data this "
+                     f"checkout cannot vouch for (fetch older than "
+                     f"{args.max_fetch_age_days:g}d, behind, or no upstream)")
 
+    # THE FLOOR OUTRANKS EVERYTHING BELOW IT. Moved above the could-not-assess
+    # branch to match check-workflow-health.py, which learned it the hard way:
+    # when coverage has collapsed, the most informative thing to say is that it
+    # collapsed. Both paths already returned 2, so this changes which reason gets
+    # printed, not which verdict is reached.
     if args.require_plugins and inspected < args.require_plugins:
         print(f"FAIL: inspected {inspected} plugin(s), required at least "
               f"{args.require_plugins}. Nothing was checked — a pass here would "
               f"be meaningless.\n  root: {estate or root}", file=sys.stderr)
+        print(f"parity: {inspected} plugin(s) inspected, below the floor of "
+              f"{args.require_plugins}")
         return 2
 
     if drift:
@@ -180,9 +329,24 @@ def main(argv=None):
               f"Regenerate with the monorepo's scripts/gen-kimi-manifests.py, "
               f"then commit kimi.plugin.json alongside the version bump.",
               file=sys.stderr)
+        print(f"parity: {len(drift)} of {inspected} plugin(s) out of "
+              f"parity{staleness}")
         return 1
 
-    print(f"parity ok: {inspected} plugin(s)")
+    # A finding this checkout is too stale to stand behind is not a pass and not
+    # a finding. The old rule fired only when the stale count OUTNUMBERED the
+    # drift count, which let a single unassessable plugin be rounded away by two
+    # real ones — the one plugin nobody could judge is exactly the one worth
+    # saying out loud.
+    if unassessable:
+        print(f"\nCANNOT ASSESS: {len(unassessable)} of {inspected} plugin(s) had "
+              f"a parity finding this checkout is too stale to stand behind. Pull "
+              f"them, then re-run.", file=sys.stderr)
+        print(f"parity unassessable: {len(unassessable)} of {inspected} "
+              f"plugin(s) too stale to judge{staleness}")
+        return 2
+
+    print(f"parity ok: {inspected} plugin(s){staleness}")
     return 0
 
 

--- a/tests/test_check_kimi_version_parity.py
+++ b/tests/test_check_kimi_version_parity.py
@@ -13,6 +13,9 @@ monorepo is a checkout where that happens by default.
 
 import importlib.util
 import json
+import os
+import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -145,3 +148,386 @@ def test_live_estate_is_in_parity(required):
     if not (root / "interverse").is_dir():
         pytest.skip("interverse/ not materialised in this checkout")
     assert parity.main(["--estate", str(root), "--require-plugins", str(required)]) == 0
+
+
+# ---------------------------------------------------------------------------
+# The freshness guard: how old the evidence is, and whether it may be used to
+# accuse a plugin of drift.
+#
+# WHY THESE EXIST
+#
+# behind_remote() shipped with no test at all, and both of its defects were the
+# kind a test written from the docstring would have caught:
+#
+#   1. It was CALLED ONLY when kimi.plugin.json was missing. The far more common
+#      shape — the file present, its version behind a bumped plugin.json because
+#      the checkout has not pulled the regeneration — never reached the guard.
+#      That is the interlore case on 2026-08-07: fixed on the remote on 08-03,
+#      reported as drift on Clavain, clean on zklw, and read at the time as a
+#      coverage gap between the machines.
+#
+#   2. It compared against @{upstream} WITHOUT FETCHING, and returned the plain
+#      integer 0 for "level with the remote", for "no upstream", and for "git
+#      failed". On a clone that last fetched five weeks ago the comparison is
+#      between two local pointers and the remote is not consulted at all.
+#      Measured: 55 of 70 Clavain checkouts reported "0 behind" on fetch data
+#      older than seven days, twelve having never fetched; zklw had 65 of 66
+#      within the week. Same integer from both machines.
+#
+# These build real git repositories rather than monkeypatching, because the bug
+# was in what git was actually asked and when.
+# ---------------------------------------------------------------------------
+
+def _run(*args, cwd):
+    subprocess.run(args, cwd=str(cwd), check=True,
+                   capture_output=True, text=True)
+
+
+def _repo(path: Path, canonical: str, generated: str | None):
+    """A plugin repo with an origin it tracks, and one commit on both sides."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    origin = path.parent / (path.name + ".origin.git")
+    _run("git", "init", "--quiet", "--bare", "-b", "main", str(origin),
+         cwd=path.parent)
+    path.mkdir(parents=True, exist_ok=True)
+    _run("git", "init", "--quiet", "-b", "main", ".", cwd=path)
+    _run("git", "config", "user.email", "t@example.invalid", cwd=path)
+    _run("git", "config", "user.name", "t", cwd=path)
+    _run("git", "config", "commit.gpgsign", "false", cwd=path)
+    _plugin(path, canonical, generated)
+    _run("git", "add", "-A", cwd=path)
+    _run("git", "commit", "--quiet", "-m", "init", cwd=path)
+    _run("git", "remote", "add", "origin", str(origin), cwd=path)
+    _run("git", "push", "--quiet", "-u", "origin", "main", cwd=path)
+    return path
+
+
+def _fetch_age(path: Path, days: float | None):
+    """Set, or erase, this repo's record of when it last contacted its remote."""
+    common = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "--git-common-dir"],
+        capture_output=True, text=True, check=True).stdout.strip()
+    p = Path(common)
+    if not p.is_absolute():
+        p = path / p
+    head = p / "FETCH_HEAD"
+    if days is None:
+        head.unlink(missing_ok=True)
+        return
+    head.touch()
+    when = time.time() - days * 86400
+    os.utime(head, (when, when))
+
+
+def _advance_remote(path: Path):
+    """Put a commit on the origin that `path` has not seen, and let it notice."""
+    origin = path.parent / (path.name + ".origin.git")
+    other = path.parent / (path.name + ".other")
+    _run("git", "clone", "--quiet", str(origin), str(other), cwd=path.parent)
+    _run("git", "config", "user.email", "t@example.invalid", cwd=other)
+    _run("git", "config", "user.name", "t", cwd=other)
+    _run("git", "config", "commit.gpgsign", "false", cwd=other)
+    (other / "NOTE").write_text("moved on\n")
+    _run("git", "add", "-A", cwd=other)
+    _run("git", "commit", "--quiet", "-m", "remote moves", cwd=other)
+    _run("git", "push", "--quiet", "origin", "main", cwd=other)
+    _run("git", "fetch", "--quiet", "origin", cwd=path)
+
+
+def _estate(root: Path):
+    """--estate walks os/Clavain and interverse/*; give it one real plugin."""
+    (root / "interverse").mkdir(parents=True, exist_ok=True)
+    return root / "interverse" / "alpha"
+
+
+# --- blind spot 1: the guard was wired to the wrong branch -----------------
+
+def test_a_present_but_stale_manifest_is_not_called_drift(tmp_path, capsys):
+    """THE INTERLORE SHAPE, and the one the shipped guard could not see.
+
+    kimi.plugin.json is present and its version trails a bumped plugin.json.
+    That is what a stale checkout looks like after someone else regenerated and
+    pushed — and it is also what real drift looks like, which is the whole reason
+    the freshness of the checkout has to decide between them.
+
+    The shipped code consulted the remote only under `if not generated.is_file()`,
+    so this path reached `got != want` and reported DRIFT without ever asking
+    whether this clone was entitled to an opinion.
+    """
+    root = tmp_path / "estate"
+    plugin = _repo(_estate(root), "1.2.4", "1.2.3")
+    _advance_remote(plugin)  # now genuinely behind its remote
+
+    assert parity.main(["--estate", str(root), "--require-plugins", "1"]) == 2
+    err = capsys.readouterr().err
+    assert "STALE" in err
+    assert "behind its remote" in err
+    # The accusation it withheld is named, not merely withheld.
+    assert "version bumped without regenerating" in err
+    assert "DRIFT" not in err
+
+
+def test_a_missing_manifest_on_a_stale_checkout_is_still_guarded(tmp_path):
+    """The one branch that was wired correctly. It must stay wired."""
+    root = tmp_path / "estate"
+    plugin = _repo(_estate(root), "1.2.3", None)
+    _advance_remote(plugin)
+    assert parity.main(["--estate", str(root), "--require-plugins", "1"]) == 2
+
+
+def test_an_unreadable_manifest_on_a_stale_checkout_is_not_convicted(tmp_path):
+    """A deliberate change of position, recorded because the old one was argued.
+
+    The previous comment routed unreadable manifests to DRIFT on the grounds that
+    a corrupt file "travels with the repo, and pulling will not fix it". That is
+    true of a file corrupt on the remote and false of one corrupt only here — a
+    truncated checkout, an interrupted write, a file the remote has since
+    repaired. The check cannot tell those apart without looking at the remote,
+    and looking is exactly what a stale clone cannot do. So the rule is now
+    uniform: no accusation of any kind rests on evidence this checkout cannot
+    stand behind.
+    """
+    root = tmp_path / "estate"
+    plugin = _repo(_estate(root), "1.0.0", "1.0.0")
+    (plugin / "kimi.plugin.json").write_text("{ not json\n")
+    _advance_remote(plugin)
+    assert parity.main(["--estate", str(root), "--require-plugins", "1"]) == 2
+
+
+# --- blind spot 2: "0 behind" from a ref nobody refreshed ------------------
+
+def test_zero_behind_from_a_month_old_ref_is_not_evidence(tmp_path, capsys):
+    """The defect that made 2026-08-07 unreadable.
+
+    Nothing here fetches, so `HEAD..@{upstream}` compares two local pointers.
+    This repo is level with the remote-tracking ref it happens to hold, and that
+    ref was last refreshed 35 days ago — the measured age of interdoc, interdeep,
+    interfluence and 41 others on Clavain. The old code returned 0 and the caller
+    read 0 as "up to date".
+    """
+    root = tmp_path / "estate"
+    plugin = _repo(_estate(root), "1.2.4", "1.2.3")
+    _fetch_age(plugin, 35.0)
+
+    assert parity.main(["--estate", str(root), "--require-plugins", "1"]) == 2
+    err = capsys.readouterr().err
+    assert "STALE" in err
+    assert "35d ago" in err
+
+
+def test_never_fetched_is_not_the_same_as_up_to_date(tmp_path, capsys):
+    """Twelve Clavain checkouts have no FETCH_HEAD at all."""
+    root = tmp_path / "estate"
+    plugin = _repo(_estate(root), "1.2.4", "1.2.3")
+    _fetch_age(plugin, None)
+
+    assert parity.main(["--estate", str(root), "--require-plugins", "1"]) == 2
+    assert "never fetched" in capsys.readouterr().err
+
+
+def test_a_fresh_checkout_still_convicts(tmp_path, capsys):
+    """THE TEST THAT STOPS THE FIX FROM BEING A MUTE BUTTON.
+
+    Every assertion above turns a finding into a refusal, and a guard that
+    refuses unconditionally would satisfy all of them while reporting nothing
+    ever again. Same drift, same code path, a clone that fetched an hour ago:
+    exit 1, DRIFT, no STALE.
+    """
+    root = tmp_path / "estate"
+    plugin = _repo(_estate(root), "1.2.4", "1.2.3")
+    _fetch_age(plugin, 1.0 / 24)
+
+    assert parity.main(["--estate", str(root), "--require-plugins", "1"]) == 1
+    err = capsys.readouterr().err
+    assert "DRIFT" in err
+    assert "STALE" not in err
+
+
+def test_the_threshold_is_the_thing_being_tested(tmp_path):
+    """Same repo, same drift; only --max-fetch-age-days moves."""
+    root = tmp_path / "estate"
+    plugin = _repo(_estate(root), "1.2.4", "1.2.3")
+    _fetch_age(plugin, 10.0)
+
+    assert parity.main(["--estate", str(root), "--require-plugins", "1",
+                        "--max-fetch-age-days", "7"]) == 2
+    assert parity.main(["--estate", str(root), "--require-plugins", "1",
+                        "--max-fetch-age-days", "30"]) == 1
+
+
+# --- the guard must not disable the check where it is enforced -------------
+
+def test_root_mode_convicts_on_a_detached_head(tmp_path, capsys):
+    """CI's shape, and the reason the guard is estate-only.
+
+    A plugin repo's CI checks out a detached HEAD, where @{upstream} does not
+    resolve. If "cannot resolve upstream" meant "cannot judge" everywhere, the
+    pre-commit hook and every plugin CI would go quiet — exiting 0 forever while
+    inspecting a tree it had decided not to have an opinion about. In --root mode
+    the checkout is the subject, not a stand-in for one, so it is judged.
+    """
+    plugin = _repo(tmp_path / "solo", "1.2.4", "1.2.3")
+    sha = subprocess.run(["git", "-C", str(plugin), "rev-parse", "HEAD"],
+                         capture_output=True, text=True, check=True).stdout.strip()
+    _run("git", "checkout", "--quiet", "--detach", sha, cwd=plugin)
+    _fetch_age(plugin, None)
+
+    assert parity.main(["--root", str(plugin), "--require-plugins", "1"]) == 1
+    assert "DRIFT" in capsys.readouterr().err
+
+
+def test_a_directory_that_is_not_a_repo_is_judged_on_its_files(tmp_path):
+    """No git, no remote, nothing that could be stale — so decide."""
+    root = tmp_path / "estate"
+    _plugin(_estate(root), "1.2.4", "1.2.3")
+    assert parity.main(["--estate", str(root), "--require-plugins", "1"]) == 1
+
+
+# --- reporting the staleness rather than assuming it -----------------------
+
+def test_a_pass_says_how_old_the_evidence_behind_it_is(tmp_path, capsys):
+    """A green run on unrefreshed clones must not read like a green run.
+
+    The manifests agree, so there is no accusation to withhold and the verdict
+    stays 0 — a stale clone produces a coverage limit here, not a false charge.
+    But the run rests on data nobody refreshed, and the summary line is what
+    rig-report.sh publishes to the health record, so that is where it has to be
+    said. On Clavain this is 55 of 70.
+    """
+    root = tmp_path / "estate"
+    plugin = _repo(_estate(root), "1.2.3", "1.2.3")
+    _fetch_age(plugin, 40.0)
+
+    assert parity.main(["--estate", str(root), "--require-plugins", "1"]) == 0
+    out = capsys.readouterr().out
+    assert "parity ok: 1 plugin(s)" in out
+    assert "1 of 1 judged on remote data this checkout cannot vouch for" in out
+    # The clause names all three states it covers. Measured on Clavain, this
+    # count was 65: 44 stale fetches, 12 never fetched, 9 known-behind and 1 with
+    # no upstream. An earlier version of this line attributed all 65 to fetch
+    # age, which was false for ten of them.
+    assert "behind, or no upstream" in out
+
+
+def test_a_fresh_pass_claims_nothing_extra(tmp_path, capsys):
+    root = tmp_path / "estate"
+    plugin = _repo(_estate(root), "1.2.3", "1.2.3")
+    _fetch_age(plugin, 0.5)
+
+    assert parity.main(["--estate", str(root), "--require-plugins", "1"]) == 0
+    out = capsys.readouterr().out.strip()
+    assert out.endswith("parity ok: 1 plugin(s)")
+
+
+def test_every_exit_path_leaves_a_summary_on_stdout(tmp_path, capsys):
+    """rig-report.sh publishes `tail -1` of stdout as the health summary.
+
+    Before this, only the exit-0 path printed to stdout, so a run that found
+    drift or refused to judge handed the health record whatever happened to be
+    there. estate-drift lost its verdict to exactly this and published a sentence
+    about bead housekeeping instead.
+    """
+    root = tmp_path / "estate"
+    plugin = _repo(_estate(root), "1.2.4", "1.2.3")
+    _fetch_age(plugin, 0.1)
+    assert parity.main(["--estate", str(root), "--require-plugins", "1"]) == 1
+    assert "out of parity" in capsys.readouterr().out.strip().splitlines()[-1]
+
+    _fetch_age(plugin, 90.0)
+    assert parity.main(["--estate", str(root), "--require-plugins", "1"]) == 2
+    assert "unassessable" in capsys.readouterr().out.strip().splitlines()[-1]
+
+    assert parity.main(["--estate", str(root), "--require-plugins", "99"]) == 2
+    assert "below the floor" in capsys.readouterr().out.strip().splitlines()[-1]
+
+
+def test_the_floor_outranks_a_refusal_to_judge(tmp_path, capsys):
+    """Both return 2; which reason is printed is the point.
+
+    When one plugin was found where sixty were required, the useful sentence is
+    that coverage collapsed — not that the single plugin found was too stale to
+    judge. check-workflow-health.py orders these the same way.
+    """
+    root = tmp_path / "estate"
+    plugin = _repo(_estate(root), "1.2.4", "1.2.3")
+    _fetch_age(plugin, 90.0)
+    assert parity.main(["--estate", str(root), "--require-plugins", "60"]) == 2
+    err = capsys.readouterr().err
+    assert "required at least 60" in err
+    assert "CANNOT ASSESS" not in err
+
+
+def test_a_confirmed_finding_is_not_buried_by_a_majority_of_gaps(tmp_path, capsys):
+    """One drift that is certain, two plugins nobody can judge.
+
+    Written this way round on purpose. The obvious version of this test — two
+    convictable and one stale — cannot tell the old rule from the new one: the
+    old `len(unassessable) > len(drift)` is false at 1 > 2, so it falls through
+    to the same exit 1 the new code reaches directly, and the assertion passes
+    against both. It looks like coverage and is not.
+
+    Inverting the ratio is what separates them. At 2 > 1 the old rule returned 2,
+    CANNOT ASSESS, and the confirmed finding vanished behind a caveat about
+    OTHER plugins — a plugin proven out of parity, on a checkout fresh enough to
+    prove it, downgraded to "could not tell" by the arithmetic of its neighbours.
+    Now the finding is reported and the gaps are reported alongside it.
+    """
+    root = tmp_path / "estate"
+    fresh = _repo(root / "interverse" / "a", "1.0.1", "1.0.0")
+    stale_b = _repo(root / "interverse" / "b", "2.0.1", "2.0.0")
+    stale_c = _repo(root / "interverse" / "c", "3.0.1", "3.0.0")
+    _fetch_age(fresh, 0.1)
+    _fetch_age(stale_b, 99.0)
+    _fetch_age(stale_c, 99.0)
+
+    assert parity.main(["--estate", str(root), "--require-plugins", "3"]) == 1
+    err = capsys.readouterr().err
+    assert "DRIFT  a" in err
+    # Neither gap is silently absorbed into the finding.
+    assert "STALE  b" in err
+    assert "STALE  c" in err
+
+
+# --- remote_evidence() as a unit -------------------------------------------
+
+def test_evidence_separates_cannot_tell_from_up_to_date(tmp_path):
+    """The conflation that started all of this.
+
+    behind_remote() returned the int 0 for both. These are the two states, and
+    they must not compare equal.
+    """
+    level = _repo(tmp_path / "level", "1.0.0", "1.0.0")
+    _fetch_age(level, 0.1)
+    good = parity.remote_evidence(level, 7.0)
+    assert good.trustworthy and good.behind == 0
+
+    orphan = _repo(tmp_path / "orphan", "1.0.0", "1.0.0")
+    _run("git", "checkout", "--quiet", "-b", "local-only", cwd=orphan)
+    blind = parity.remote_evidence(orphan, 7.0)
+    assert not blind.trustworthy
+    assert blind.behind is None
+    assert "remote-tracking" in blind.reason
+
+
+def test_evidence_reports_the_age_it_used(tmp_path):
+    plugin = _repo(tmp_path / "aged", "1.0.0", "1.0.0")
+    _fetch_age(plugin, 12.0)
+    ev = parity.remote_evidence(plugin, 7.0)
+    assert not ev.trustworthy
+    assert ev.fetch_age_days is not None
+    assert 11.9 < ev.fetch_age_days < 12.1
+
+
+def test_a_worktree_reads_the_common_dir_for_its_fetch_record(tmp_path):
+    """FETCH_HEAD lives in the common dir, not the worktree's own .git file.
+
+    Sylveste's own estate work runs from `bd worktree` checkouts, so resolving
+    this wrongly would report every worktree as never-fetched — a whole machine
+    turned unassessable by a path bug.
+    """
+    plugin = _repo(tmp_path / "main-wt", "1.0.0", "1.0.0")
+    _fetch_age(plugin, 0.1)
+    wt = tmp_path / "linked-wt"
+    _run("git", "worktree", "add", "--quiet", str(wt), "-b", "wt", cwd=plugin)
+    age = parity.last_fetch_age_days(wt)
+    assert age is not None and age < 1.0


### PR DESCRIPTION
## What

`behind_remote()` exists to stop a checkout that has not pulled from crying wolf. It shipped with no test, and it had two defects that between them meant it had never once done that job.

**It was wired to the wrong branch.** It was consulted only under `if not generated.is_file()`. The shape that actually recurs is `kimi.plugin.json` **present** and trailing a bumped `plugin.json` — what a clone looks like after someone else regenerated and pushed. That path ran `got != want` and reported DRIFT without the guard ever being called.

**It could not tell "level with the remote" from "I did not look."** It returned a plain `int`, and returned `0` for up-to-date, for no upstream, and for git failing. The count came from `HEAD..@{upstream}`, and nothing refreshes `@{upstream}` — so on a clone that last fetched five weeks ago the comparison is between two local pointers and the remote is not involved.

## Why 2026-08-07 was misread

| | fetched ≤7d | never fetched | judged on data the checkout cannot vouch for |
|---|---|---|---|
| Clavain | 14 of 70 | 12 | **65 of 70** |
| zklw | 65 of 66 | 0 | 1 of 66 |

Both machines put the same integer `0` through that function. Only one had measured anything. That is the whole of the apparent "coverage gap": `interlore` was fixed on the remote on 08-03, Clavain had not fetched, and the guard built for precisely that returned 0.

## Reproduced, not argued

`interleave` copied with its mtimes so the copy is as stale as the original, one version bump planted:

| checkout | last fetch | shipped | fixed |
|---|---|---|---|
| Clavain | 36.7d | `DRIFT` exit 1 | `STALE` exit 2 |
| zklw | 0.6d | `DRIFT` exit 1 | `DRIFT` exit 1 |

Same plugin, same plant, opposite verdicts. The second row is the one that matters: a guard that suppressed findings unconditionally would satisfy every assertion about the first row and be worthless.

## No fetch, deliberately

A read-only check must not mutate the repos it inspects — an unattended timer fetching 70 clones changes their state and can race a session mid-rebase. So staleness is **reported** rather than resolved. Freshening the estate stays autosync's job, and on the machine where autosync runs, this returns trustworthy.

## The freshness rule is estate-mode only

`--root` is a plugin repo checking **itself**, in its own CI and pre-commit hook, where the tree is the subject rather than a stand-in for one — and CI checks out a detached HEAD, where `@{upstream}` does not resolve. A guard reading "no upstream" as "cannot judge" everywhere would switch the check off exactly where it is enforced, and it would go on exiting 0 while inspecting nothing. `test_root_mode_convicts_on_a_detached_head` pins it.

## Two smaller things, same visit

- The `--require-plugins` floor now outranks the refusal to judge, matching `check-workflow-health.py`. Both already returned 2; this changes which reason prints.
- **Every exit path now leaves a summary on stdout.** `rig-report.sh` publishes `tail -1`, and only the exit-0 path printed there — so a run that found drift handed the health record whatever was lying around. `estate-drift` lost its verdict to this same mechanism last week and published a sentence about bead housekeeping instead.

A pass now says what it rests on:

```
parity ok: 70 plugin(s); 65 of 70 judged on remote data this checkout cannot vouch for
```

That clause names three states because an earlier draft said "judged from fetch data older than 7d", which was false for ten of the 65 — nine clones fresh enough to *know* they were behind, one with no upstream.

## Verification

- 17 new tests; **154 in the suite with plugins materialised, 0 skipped, 0 failed**.
- **15 mutations, 0 survivors.** One survived the first pass and was *equivalent* rather than a gap: restoring the old `len(unassessable) > len(drift)` condition changes nothing once the drift verdict moved above it, since `len(drift)` is 0 by the time that line is reached. Replaced with the mutation that does carry the semantics — the old condition **and** its old precedence — which dies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
